### PR TITLE
[app insights] don't track full URL values

### DIFF
--- a/src-packed/appinsights.js
+++ b/src-packed/appinsights.js
@@ -1,4 +1,5 @@
 const { appinsights_key } = require("./secrets");
+const { isTests } = require("./settings");
 
 import { ApplicationInsights } from '@microsoft/applicationinsights-web'
 
@@ -10,10 +11,44 @@ const appinsights = new ApplicationInsights({
         //enableDebug: true,
     }
 });
-appinsights.loadAppInsights();
-appinsights.addTelemetryInitializer(function (envelope) {
+
+// Don't enable these in "unit test" mode
+if (!isTests) {
+    appinsights.loadAppInsights();
+    appinsights.addTelemetryInitializer(telemetryInitializer);
+}
+
+export function telemetryInitializer (envelope) {
     envelope.tags["ai.application.ver"] = '0.1.0';
-});
+
+    // We don't want to report full URLs
+    if (envelope.baseData.uri) {
+        var url = new URL(envelope.baseData.uri);
+        if (url.hostname == "github.com") {
+            var parts = url.pathname.split('/');
+            envelope.baseData.name = 'github';
+            if (parts.length > 3) {
+                envelope.baseData.uri = 'https://github.com/' + parts[1] + "/" + parts[2];
+            } else {
+                envelope.baseData.uri = 'https://github.com';
+            }
+        } else if (url.hostname == 'dev.azure.com') {
+            envelope.baseData.name = 'azdo';
+        } else if (url.hostname == 'devdiv.visualstudio.com') {
+            envelope.baseData.name = 'azdo';
+        } else {
+            envelope.baseData.name = 'not_specified';
+            envelope.baseData.uri = 'not_specified';
+        }
+    }
+
+    // Try to clear other information
+    envelope.tags["ai.operation.name"] = envelope.baseData.name;
+    if (envelope.baseData.refUri)
+        envelope.baseData.refUri = envelope.baseData.uri;
+    if (envelope.ext && envelope.ext.trace && envelope.ext.trace.name)
+        envelope.ext.trace.name = envelope.baseData.name;
+}
 
 export function trackPageView() {
     appinsights.trackPageView();

--- a/src-packed/settings.js
+++ b/src-packed/settings.js
@@ -1,0 +1,1 @@
+export var isTests = false;

--- a/test/appinsights.js
+++ b/test/appinsights.js
@@ -1,12 +1,70 @@
 describe('appinsights', () => {
-    // NOTE: comment out, in order to run these tests.
-    // Usage of app insights causes tests to never exit, and I didn't figure out how to fix it.
-    // I could call process.exit(0), but then test failures had a successful exit code.
-    return;
+    // Enable "unit test" mode
+    require("../src-packed/settings").isTests = true;
 
-    const appinsights = require('../src-packed/appinsights');
+    const appinsights = require('../src-packed/appinsights')
 
-    it('trackEvent', async () => {
+    it('trackEvent', () => {
         appinsights.trackEvent("test event 3", { key: "value" });
+    });
+
+    const data = {
+        baseData: { name:"", uri: "" },
+        tags: { }
+    };
+
+    it('pageView not specified', () => {
+        data.baseData.name = "Don't show this";
+        data.baseData.uri = "https://somesite.com/should/not/show";
+        appinsights.telemetryInitializer (data);
+
+        expect(data.baseData.name).to.be.equal('not_specified');
+        expect(data.baseData.uri).to.be.equal('not_specified');
+        expect(data.tags['organization']).to.be.equal(undefined);
+    });
+
+    it('pageView null uri', () => {
+        data.baseData.name = undefined;
+        data.baseData.uri = undefined;
+        appinsights.telemetryInitializer (data);
+
+        expect(data.baseData.name).to.be.equal(undefined);
+        expect(data.baseData.uri).to.be.equal(undefined);
+    });
+
+    it('pageView for github', () => {
+        data.baseData.name = "Don't show this";
+        data.baseData.uri = "https://github.com/jonathanpeppers/inclusive-code-comments/issues";
+        appinsights.telemetryInitializer (data);
+
+        expect(data.baseData.name).to.be.equal('github');
+        expect(data.baseData.uri).to.be.equal('https://github.com/jonathanpeppers/inclusive-code-comments');
+    });
+
+    it('pageView for github missing parts', () => {
+        data.baseData.name = "Don't show this";
+        data.baseData.uri = "https://github.com";
+        appinsights.telemetryInitializer (data);
+
+        expect(data.baseData.name).to.be.equal('github');
+        expect(data.baseData.uri).to.be.equal('https://github.com');
+    });
+
+    it('pageView for devdiv azdo', () => {
+        data.baseData.name = "Don't show this";
+        data.baseData.uri = "https://devdiv.visualstudio.com/DevDiv/_build?definitionId=13330&_a=summary";
+        appinsights.telemetryInitializer (data);
+
+        expect(data.baseData.name).to.be.equal('azdo');
+        expect(data.baseData.uri).to.be.equal('https://devdiv.visualstudio.com/DevDiv/_build?definitionId=13330&_a=summary');
+    });
+
+    it('pageView for dnceng azdo', () => {
+        data.baseData.name = "Don't show this";
+        data.baseData.uri = "https://dev.azure.com/dnceng/public/_packaging?_a=feed&feed=dotnet6";
+        appinsights.telemetryInitializer (data);
+
+        expect(data.baseData.name).to.be.equal('azdo');
+        expect(data.baseData.uri).to.be.equal('https://dev.azure.com/dnceng/public/_packaging?_a=feed&feed=dotnet6');
     });
 });


### PR DESCRIPTION
Fixes: https://github.com/jonathanpeppers/inclusive-code-comments/issues/22

We should only be tracking the github or azdo organization and not full URLs.

I also figured out how to unit test `appinsights.js`, so that is now enabled.