### PR TITLE
Replace `inline code blocks` with #code

### DIFF
--- a/src-packed/textAnalytics.js
+++ b/src-packed/textAnalytics.js
@@ -69,11 +69,10 @@ function removeCodeBlocks (text) {
     return result;
 }
 
-// Replace backticks for double quotes, since backticks make sentiment more negative
-// See textAnalytics.js 'Yield Example' test
+const backtickRegex = /`[^`]+`/gi;
+
 function replaceBackticks (text) {
-    var result = text.replace(/`/g, "\"");
-    return result;
+    return text.replace(backtickRegex, '#code');
 }
 
 const githubHandleRegex = /\B@([a-z0-9](?:-(?=[a-z0-9])|[a-z0-9]){0,38}(?<=[a-z0-9]))/gi;
@@ -87,7 +86,6 @@ function replaceGitHubHandles (text) {
 export function preprocessText (text) {
     var result = removeCodeBlocks (text);
     result = removeImageTags (result);
-    result = replaceBackticks (result);
     return result;
 }
 
@@ -95,6 +93,7 @@ export function preprocessText (text) {
 // These do not need to preserve text length
 export function postprocessText (text) {
     var result = replaceGitHubHandles(text);
+    result = replaceBackticks(result);
     //TODO: do a real punctuation remover
     return result.replace('!', ' ').trim();
 }

--- a/test/textAnalytics.js
+++ b/test/textAnalytics.js
@@ -92,6 +92,15 @@ This code is stupid.`
         expect(result).to.be.equal("This is not a handle: @?1234");
     });
 
+    it('Inline code blocks', () => {
+        var result = client.postprocessText ("Put this in your `AndroidManifest.xml` file");
+        expect(result).to.be.equal("Put this in your #code file");
+        var result = client.postprocessText ("`Change the backticks`");
+        expect(result).to.be.equal("#code");
+        var result = client.postprocessText ("This is not a code block: ` Hello");
+        expect(result).to.be.equal("This is not a code block: ` Hello");
+    });
+
     it("Ignorable sentence", async () => {
         const result = await client.analyzeSentiment(ort, "I see a couple of new warnings and errors.");
         expect(result.sentences[0].sentiment).not.to.be.equal("negative");
@@ -146,11 +155,6 @@ This code is stupid.`
         const result = await client.analyzeSentiment(ort, ["abc![I am good](https://good.com/)","![You are bad](https://bad.com/)"]);
         expect(result.sentences[0].sentiment).to.be.equal("neutral");
         expect(result.sentences[1].sentiment).to.be.equal("negative");
-    });
-
-    it('Replace Backticks', async () => {
-        const result = await client.analyzeSentiment(ort, "`Change the backticks`");
-        expect(result.sentences[0].text).to.be.equal("\"Change the backticks\"");
     });
 
     it('Yield Example', async () => {


### PR DESCRIPTION
Context: https://github.com/jonathanpeppers/inclusive-code-reviews-browser/issues/132

Future work will need to be done on the ML side:
* Replace the same way when loading/saving `.csv` files
* Replace our existing data & update the model
* Document this replacement