### PR TITLE
Update regex to allow triple backtick code blocks

### DIFF
--- a/src-packed/textAnalytics.js
+++ b/src-packed/textAnalytics.js
@@ -69,7 +69,7 @@ function removeCodeBlocks (text) {
     return result;
 }
 
-const backtickRegex = /`[^`]+`/gi;
+const backtickRegex = /`+[^`]+`+/gi;
 
 function replaceBackticks (text) {
     return text.replace(backtickRegex, '#code');

--- a/test/textAnalytics.js
+++ b/test/textAnalytics.js
@@ -95,6 +95,8 @@ This code is stupid.`
     it('Inline code blocks', () => {
         var result = client.postprocessText ("Put this in your `AndroidManifest.xml` file");
         expect(result).to.be.equal("Put this in your #code file");
+        var result = client.postprocessText ("Put this in your ```AndroidManifest.xml``` file");
+        expect(result).to.be.equal("Put this in your #code file");
         var result = client.postprocessText ("`Change the backticks`");
         expect(result).to.be.equal("#code");
         var result = client.postprocessText ("This is not a code block: ` Hello");


### PR DESCRIPTION
Context: https://github.com/jonathanpeppers/inclusive-code-reviews-ml/pull/57
Context: https://github.com/jonathanpeppers/inclusive-code-reviews-ml/issues/48

Allows things like:

    This is a ```code block```