### PR TITLE
Trim trailing punctuation

### DIFF
--- a/src-packed/textAnalytics.js
+++ b/src-packed/textAnalytics.js
@@ -81,6 +81,12 @@ function replaceGitHubHandles (text) {
     return text.replace(githubHandleRegex, '@github');
 }
 
+const punctuationRegex = /(\.|!|\?|;|:)+$/g;
+
+function replaceTrailingPunctuation (text) {
+    return text.replace(punctuationRegex, '');
+}
+
 // These are transformations applied, before it is split into sentences
 // These need to preserve text length
 export function preprocessText (text) {
@@ -92,10 +98,10 @@ export function preprocessText (text) {
 // These are transformations applied, after split into sentences
 // These do not need to preserve text length
 export function postprocessText (text) {
-    var result = replaceGitHubHandles(text);
-    result = replaceBackticks(result);
-    //TODO: do a real punctuation remover
-    return result.replace('!', ' ').trim();
+    const github_replaced = replaceGitHubHandles(text);
+    const backticks_replaced = replaceBackticks(github_replaced);
+    const punctuation_replaced = replaceTrailingPunctuation(backticks_replaced);
+    return punctuation_replaced.trim();
 }
 
 const segmenter = new Intl.Segmenter('en', { granularity: 'sentence' });

--- a/test/textAnalytics.js
+++ b/test/textAnalytics.js
@@ -103,6 +103,19 @@ This code is stupid.`
         expect(result).to.be.equal("This is not a code block: ` Hello");
     });
 
+    it('Trailing punctuation', () => {
+        var result = client.postprocessText ("Just do it!");
+        expect(result).to.be.equal("Just do it");
+        var result = client.postprocessText ("Just do it!!!");
+        expect(result).to.be.equal("Just do it");
+        var result = client.postprocessText ("Just do it !!!!!!");
+        expect(result).to.be.equal("Just do it");
+        var result = client.postprocessText ("Just do it ?");
+        expect(result).to.be.equal("Just do it");
+        var result = client.postprocessText ("Just do this:");
+        expect(result).to.be.equal("Just do this");
+    });
+
     it("Ignorable sentence", async () => {
         const result = await client.analyzeSentiment(ort, "I see a couple of new warnings and errors.");
         expect(result.sentences[0].sentiment).not.to.be.equal("negative");


### PR DESCRIPTION
Fixes: https://github.com/jonathanpeppers/inclusive-code-reviews-browser/issues/123

We've found that adding a `.`, `:`, etc. can influence the results of the machine learning model. Let's trim out trailing punctuation to solve this.

Future changes need to happen in the ML model side: remove trailing punctuation from the dataset, etc.