### PR TITLE
Replace URLs with `#url`

### DIFF
--- a/src-packed/textAnalytics.js
+++ b/src-packed/textAnalytics.js
@@ -75,6 +75,12 @@ function replaceBackticks (text) {
     return text.replace(backtickRegex, '#code');
 }
 
+const urlRegex = /\b(https?|ftp|file):\/\/[\-A-Za-z0-9+&@#\/%?=~_|!:,.;]*[\-A-Za-z0-9+&@#\/%=~_|]/gi;
+
+function replaceUrls(text) {
+    return text.replace(urlRegex, '#url');
+}
+
 const githubHandleRegex = /\B@([a-z0-9](?:-(?=[a-z0-9])|[a-z0-9]){0,38}(?<=[a-z0-9]))/gi;
 
 function replaceGitHubHandles (text) {
@@ -100,7 +106,8 @@ export function preprocessText (text) {
 export function postprocessText (text) {
     const github_replaced = replaceGitHubHandles(text);
     const backticks_replaced = replaceBackticks(github_replaced);
-    const punctuation_replaced = replaceTrailingPunctuation(backticks_replaced);
+    const urls_replaced = replaceUrls(backticks_replaced);
+    const punctuation_replaced = replaceTrailingPunctuation(urls_replaced);
     return punctuation_replaced.trim();
 }
 

--- a/test/textAnalytics.js
+++ b/test/textAnalytics.js
@@ -116,6 +116,15 @@ This code is stupid.`
         expect(result).to.be.equal("Just do this");
     });
 
+    it('URLs', () => {
+        var result = client.postprocessText ("Look here: https://google.com");
+        expect(result).to.be.equal("Look here: #url");
+        var result = client.postprocessText ("See http://whatis.techtarget.com/definition/Fibonacci-sequence for details");
+        expect(result).to.be.equal("See #url for details");
+        var result = client.postprocessText ("See [this](http://whatis.techtarget.com/definition/Fibonacci-sequence) for details");
+        expect(result).to.be.equal("See [this](#url) for details"); //TODO: should be better?
+    });
+
     it("Ignorable sentence", async () => {
         const result = await client.analyzeSentiment(ort, "I see a couple of new warnings and errors.");
         expect(result.sentences[0].sentiment).not.to.be.equal("negative");


### PR DESCRIPTION
Fixes: https://github.com/jonathanpeppers/inclusive-code-reviews-browser/issues/140

This should hopefully improve reliability around URLs inline in comments.

Future changes will be needed on the ML side.