### PR TITLE
Change MIN_REVIEW_LENGTH 15 -> 9

### DIFF
--- a/src-packed/validator.js
+++ b/src-packed/validator.js
@@ -17,7 +17,7 @@ function loadAppInsights() {
 export async function getMatches(ort, text, matches) {
     loadAppInsights();
 
-    var minLength = typeof config != "undefined" ? config.MIN_REVIEW_LENGTH : 15;
+    var minLength = typeof config != "undefined" ? config.MIN_REVIEW_LENGTH : 9;
     if (text.length < minLength)
     {
         if (ignorableBriefPhraseRegex.test(text))

--- a/src/config/config.js
+++ b/src/config/config.js
@@ -41,5 +41,5 @@ const config = {
     COUPON_INTERVAL: 5184e6,
     PACKAGE: { BASIC: "Basic", PREMIUM: "Premium" },
     //these options is for inclusive reviews extension
-    MIN_REVIEW_LENGTH: 15,
+    MIN_REVIEW_LENGTH: 9,
 };

--- a/test/validator.js
+++ b/test/validator.js
@@ -69,7 +69,7 @@ describe('validator', () => {
     });
 
     it('Brief text suggestion', async () => {
-        var text = "Great changes";
+        var text = "Ok?";
         var matches = [];
         client.getMatches(ort, text, matches);
         expect(matches.length).to.be.equal(1);
@@ -78,7 +78,7 @@ describe('validator', () => {
     
     it('Brief text no suggestion', async () => {
         var matches = [];
-        client.getMatches(ort, "These changes are more than 15 characters", matches);
+        client.getMatches(ort, "Thank you", matches);
         expect(matches.length).to.be.equal(0);
     });
 


### PR DESCRIPTION
Fixes: https://github.com/jonathanpeppers/inclusive-code-reviews-browser/issues/119

This allows phrases like "Thank you" now.