### PR TITLE
Common wording pattern that can be soften

### DIFF
--- a/src-packed/suggestions.js
+++ b/src-packed/suggestions.js
@@ -74,6 +74,8 @@ const allReplacements = {
     // ageist
     "grandfather": ["flagship", "established", "rollover", "carryover", "classic"],
     "legacy": ["flagship", "established", "rollover", "carryover", "classic"],
+    // common wording pattern that might be softer
+    "should just": ["can probably"],
     // custom negative sentiment just leave replacements empty
     // https://www.oxfordinternationalenglish.com/dictionary-of-british-slang/
     "is pants": [],

--- a/test/suggestions.js
+++ b/test/suggestions.js
@@ -11,7 +11,7 @@ describe('suggestions', () => {
         expect(result[0]).to.eql({
             index: 0,
             length: 6,
-            replacements: [ { value: "main" }, { value: "primary" } ],
+            replacements: [{ value: "main" }, { value: "primary" }],
         });
     });
 
@@ -20,7 +20,7 @@ describe('suggestions', () => {
         expect(result[0]).to.eql({
             index: 14,
             length: 6,
-            replacements: [ { value: "main" }, { value: "primary" } ],
+            replacements: [{ value: "main" }, { value: "primary" }],
         });
     });
 
@@ -29,7 +29,7 @@ describe('suggestions', () => {
         expect(result[0]).to.eql({
             index: 17,
             length: 6,
-            replacements: [ { value: "main" }, { value: "primary" } ],
+            replacements: [{ value: "main" }, { value: "primary" }],
         });
     });
 
@@ -38,7 +38,7 @@ describe('suggestions', () => {
         expect(result[0]).to.eql({
             index: 17,
             length: 6,
-            replacements: [ { value: "Main" }, { value: "Primary" } ],
+            replacements: [{ value: "Main" }, { value: "Primary" }],
         });
     });
 
@@ -47,7 +47,7 @@ describe('suggestions', () => {
         expect(result[0]).to.eql({
             index: 7,
             length: 11,
-            replacements: [ { value: "elevating" }, { value: "exceeding expectations" }, { value: "excelling" } ],
+            replacements: [{ value: "elevating" }, { value: "exceeding expectations" }, { value: "excelling" }],
         });
     });
 
@@ -62,19 +62,28 @@ describe('suggestions', () => {
         expect(result[0]).to.eql({
             index: 26,
             length: 9,
-            replacements: [ { value: "allowlist" }, { value: "inclusion list" },  { value: "safe list" }],
+            replacements: [{ value: "allowlist" }, { value: "inclusion list" }, { value: "safe list" }],
         });
         expect(result[1]).to.eql({
             index: 41,
             length: 9,
-            replacements: [ { value: "allowlist" }, { value: "inclusion list" },  { value: "safe list" }],
+            replacements: [{ value: "allowlist" }, { value: "inclusion list" }, { value: "safe list" }],
         });
     });
 
-    it('Nitpick', async () => {
+    it('wording pattrn: Nitpick', async () => {
         var result = client.getSuggestions("Sorry to nitpick this!");
         expect(result.length).to.be.equal(0);
         var result = client.getSuggestions("nit: mixed tabs and spaces");
         expect(result.length).to.be.equal(1);
+    });
+
+    it('wording pattrn: "should just" should be changed to "can probably"', async () => {
+        var result = client.getSuggestions("We should just delete this section.");
+        expect(result[0]).to.eql({
+            index: 3,
+            length: 11,
+            replacements: [{ value: "can probably" }],
+        });
     });
 });


### PR DESCRIPTION
This PR is adding a category of common wording pattern that might be able to change to be soften. 

"should just" is a very common saying in my native language. I get feedback from native Enlish speaker that it can be soften by changing to "can probably". e.g. "We should just delete this section" -> "We can probably delete this section".

## Verification
![image](https://user-images.githubusercontent.com/22308724/202535219-d4f9f1ea-9ba6-4e54-9a80-e2fcf7248d8c.png)
