### PR TITLE
Fix Change ordering of negative sentiment vs "too brief" #153

### DIFF
--- a/src-packed/validator.js
+++ b/src-packed/validator.js
@@ -17,29 +17,6 @@ function loadAppInsights() {
 export async function getMatches(ort, text, matches) {
     loadAppInsights();
 
-    var minLength = typeof config != "undefined" ? config.MIN_REVIEW_LENGTH : 9;
-    if (text.length < minLength)
-    {
-        if (ignorableBriefPhraseRegex.test(text))
-            return matches; // return an empty list early
-
-        appinsights.trackEvent('tooShort');
-        matches.push({
-            "message": "This is comment is too brief. Could you elaborate?",
-            "shortMessage": "Comment is brief",
-            "offset": 0,
-            "length": text.length,
-            "rule": { "id": "NON_STANDARD_WORD", "subId": "1", "description": "Negative word", "issueType": ISSUE_TYPE_YELLOW, "category": { "id": "TYPOS", "name": "Small text" } },
-            "replacements": [],
-            "type": { "typeName": "Other" },
-            "ignoreForIncompleteSentence": false,
-            "contextForSureMatch": 7
-        });
-
-        //we don't need to call analytics api if the text is too short
-        return matches;
-    }
-
     // Suggestions, based on a dictionary
     suggestions.getSuggestions(text).forEach(suggestion => {
         appinsights.trackEvent('negativeWord');
@@ -85,6 +62,29 @@ export async function getMatches(ort, text, matches) {
             "contextForSureMatch": 7
         });
     });
+
+    // Check if the comment is too short
+    var minLength = typeof config != "undefined" ? config.MIN_REVIEW_LENGTH : 9;
+    if (text.length < minLength)
+    {
+        if (ignorableBriefPhraseRegex.test(text))
+            return matches; // return an empty list early
+
+        appinsights.trackEvent('tooShort');
+        matches.push({
+            "message": "This comment is too brief. Could you elaborate?",
+            "shortMessage": "Comment is brief",
+            "offset": 0,
+            "length": text.length,
+            "rule": { "id": "NON_STANDARD_WORD", "subId": "1", "description": "Negative word", "issueType": ISSUE_TYPE_YELLOW, "category": { "id": "TYPOS", "name": "Small text" } },
+            "replacements": [],
+            "type": { "typeName": "Other" },
+            "ignoreForIncompleteSentence": false,
+            "contextForSureMatch": 7
+        });
+
+        return matches;
+    }
 
     // 'manualFix' event
     if (shouldReportManualFix(matches)) {

--- a/test/validator.js
+++ b/test/validator.js
@@ -71,20 +71,20 @@ describe('validator', () => {
     it('Brief text suggestion', async () => {
         var text = "Ok?";
         var matches = [];
-        client.getMatches(ort, text, matches);
+        await client.getMatches(ort, text, matches);
         expect(matches.length).to.be.equal(1);
         expect(matches[0].length).to.be.equal(text.length);
     });
     
     it('Brief text no suggestion', async () => {
         var matches = [];
-        client.getMatches(ort, "Thank you", matches);
+        await client.getMatches(ort, "Thank you", matches);
         expect(matches.length).to.be.equal(0);
     });
 
     it('Brief text in ignore list no suggestion', async () => {
         var matches = [];
-        client.getMatches(ort, "Fixes #77", matches);
+        await client.getMatches(ort, "Fixes #77", matches);
         expect(matches.length).to.be.equal(0);
     });
 });


### PR DESCRIPTION
This PR addresses the PR Change ordering of negative sentiment vs "too brief" #153

Moving the order of checking negative sentiment before the check if the comment is too short.
Also fixes a small typo in the message if the comment is too brief.

Draft since it could still probably use a test