### PR TITLE
Don't suggest "native" -> "unmanaged"

### DIFF
--- a/src-packed/suggestions.js
+++ b/src-packed/suggestions.js
@@ -24,7 +24,7 @@ const allReplacements = {
     "slave": ["secondary", "replica", "standby"],
     "culture fit": ["values fit", "cultural contribution"],
     "minority": ["marginalized groups", "underrepresented groups"],
-    "native": ["core", "built-in", "unmanaged"],
+    "natives": [],
     // gendered 
     "guys": ["folks", "friends", "people", "you all", "y'all", "all", "everyone"],
     "ladies": ["folks", "friends", "people", "you all", "y'all", "all", "everyone"],


### PR DESCRIPTION
Fixes: https://github.com/jonathanpeppers/inclusive-code-reviews-browser/issues/172

We can always bring this back if we change our mind.

We got this response from an internal Microsoft email:

> However, after further research and discussion, we are not currently
> planning to publish guidance recommending against the use of the
> word "native." In its broader definition, the word is used as an
> adjective or a noun to describe innate characteristics or traits
> present from inception. This has been applied to people born in many
> different geographical regions, not exclusively to people of a
> certain identity. This use is not inherently derogatory or
> appropriative in any way, nor does it exclude any group or groups of
> persons (everyone can be "native" to a different area). In fact,
> "native" is used as in ethnonyms such as native Australian, Native
> Hawaiian, Alaska Native, and Native American, all of which are
> gaining acceptance as terms of ethnic pride and respect. The only
> potential negative connotation is when "native(s)" is used as a
> standalone noun in implicit but not explicit reference to an
> Indigenous group; in such cases, the speaker's bias may lend
> connotations of backwardness or primitiveness, but this is entirely
> a question of context, tone, and affect.

I left the word "natives" in with no replacement -- as I'm not sure what to suggest to replace it. Usually "native" is used in programming, so maybe it's worth just underlining it.