### PR TITLE
Other suggestions for "hit"

### DIFF
--- a/src-packed/suggestions.js
+++ b/src-packed/suggestions.js
@@ -65,7 +65,7 @@ const allReplacements = {
     // violent
     "hang": ["freeze"],
     "hanging": ["frozen", "stuck"],
-    "hit": ["click"],
+    "hit": ["click", "tap", "run into"],
     "crushing it": ["elevating", "exceeding expectations", "excelling"],
     "killing it": ["elevating", "exceeding expectations", "excelling"],
     "kill": ["stop", "cancel"],


### PR DESCRIPTION
Fixes: https://github.com/jonathanpeppers/inclusive-code-reviews-browser/issues/178

Common phrases are:

* "hit OK" -> "click OK"
* "hit OK" -> "tap OK"
* "customers hit this problem" -> "customers run into this problem"