### PR TITLE
Include page view telemetry for Azure ADO

### DIFF
--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -27,6 +27,7 @@ URLs are only recorded for:
 1. https://github.com/[organization]/[repository]
 1. https://dev.azure.com/*
 1. https://devdiv.visualstudio.com/*
+1. https://msazure.visualstudio.com/*
 
 If we don't hit one of these cases, `not_specified` will be recorded.
 

--- a/src-packed/appinsights.js
+++ b/src-packed/appinsights.js
@@ -36,6 +36,8 @@ export function telemetryInitializer (envelope) {
             envelope.baseData.name = 'azdo';
         } else if (url.hostname == 'devdiv.visualstudio.com') {
             envelope.baseData.name = 'azdo';
+        } else if (url.hostname == 'msazure.visualstudio.com') {
+            envelope.baseData.name = 'azdo';
         } else {
             envelope.baseData.name = 'not_specified';
             envelope.baseData.uri = 'not_specified';

--- a/test/appinsights.js
+++ b/test/appinsights.js
@@ -67,4 +67,13 @@ describe('appinsights', () => {
         expect(data.baseData.name).to.be.equal('azdo');
         expect(data.baseData.uri).to.be.equal('https://dev.azure.com/dnceng/public/_packaging?_a=feed&feed=dotnet6');
     });
+
+    it('pageView for azure azdo', () => {
+        data.baseData.name = "Don't show this";
+        data.baseData.uri = "https://msazure.visualstudio.com/AzureGrafanaService/_git/ResourceProvider/pullrequests?_a=mine";
+        appinsights.telemetryInitializer (data);
+
+        expect(data.baseData.name).to.be.equal('azdo');
+        expect(data.baseData.uri).to.be.equal('https://msazure.visualstudio.com/AzureGrafanaService/_git/ResourceProvider/pullrequests?_a=mine');
+    });
 });


### PR DESCRIPTION
Adding the Azure ADO org to the AppInsights telemetry allowed list.

Verification
![image](https://user-images.githubusercontent.com/22308724/212407861-6b8eb9ff-7371-400c-babf-eb58c11709ce.png)
