### PR TITLE
Add suggestions for "whitespace"

### DIFF
--- a/src-packed/suggestions.js
+++ b/src-packed/suggestions.js
@@ -17,7 +17,7 @@ const allReplacements = {
     "whitehat": ["ethical engineer", "ethical developer"],
     "grayhat": ["hacktivist"],
     "mob programming": ["team"],
-    "whitespace": ["empty space", "blank", "formatting"],
+    "whitespace": ["empty space", "horizontal space", "blank", "formatting", "indentation" ],
     "master": ["main", "primary"],
     "scrum master": ["agile lead", "agile program manager", "scrum coach", "scrum leader"],
     "web master": ["web product owner"],


### PR DESCRIPTION
ChatGPT says:

> Me: What is a more inclusive term than "whitespace"? Referring to
> space or tab characters in programming languages or text files.

> ChatGPT: "Horizontal spacing" or "indentation" are more inclusive
> terms that can be used instead of "whitespace" when referring to
> space or tab characters in programming languages or text files. The
> term "whitespace" has a historical association with the idea that
> spaces are "white" and can be considered offensive. Using more
> neutral terms such as "horizontal spacing" or "indentation" can
> avoid any potential offense and make the conversation more
> inclusive.