### PR TITLE
Set `ort.env.wasm.numThreads = 1`

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,8 @@
         ],
         "copyAsIs": [
             "./src/**/*",
-            "./node_modules/onnxruntime-web/dist/*.wasm"
+            "./node_modules/onnxruntime-web/dist/ort-wasm.wasm",
+            "./node_modules/onnxruntime-web/dist/ort-wasm-simd.wasm"
         ]
     },
     "dependencies": {

--- a/src-packed/validator.js
+++ b/src-packed/validator.js
@@ -15,6 +15,7 @@ function loadAppInsights() {
 }
 
 export async function getMatches(ort, text, matches) {
+    ort.env.wasm.numThreads = 1;
     loadAppInsights();
 
     // Suggestions, based on a dictionary


### PR DESCRIPTION
Context: https://github.com/microsoft/onnxruntime/issues/14445

When moving to Chrome V3, we hit the error:

    TypeError: URL.createObjectURL is not a function
        at Object.locateFile (packed.js:formatted:18165:126)
        at O (packed.js:formatted:345:61)
        at Object.ib (packed.js:formatted:718:49)
        at Object.mb (packed.js:formatted:722:73)
        at fe (packed.js:formatted:594:48)
        at Te (packed.js:formatted:807:42)
        at ort-wasm-simd-threaded.wasm:0x772d56
        at ort-wasm-simd-threaded.wasm:0xeb64e
        at ort-wasm-simd-threaded.wasm:0x1c4048
        at ort-wasm-simd-threaded.wasm:0xe5575

It appears we can set `numThreads` to 1 to avoid this code path.

There appear to be different `.wasm` files:

    Uncompressed Compressed
    8667133      2411351  ort-wasm-simd-threaded.wasm
    8719890      2413744  ort-wasm-simd.wasm
    7908412      2248465  ort-wasm-threaded.wasm
    7960955      2252902  ort-wasm.wasm

And it looks like we can drop the two `*-threaded.wasm` files.

Size difference:

    --14513792 release.zip
    ++ 9853726 release.zip

The extension seems to work as before, still on Chrome V2 in main.