### PR TITLE
Remove `_installUpdate()` function

### DIFF
--- a/src/background/extension-main.js
+++ b/src/background/extension-main.js
@@ -49,25 +49,10 @@ class BackgroundApp {
                 window.setInterval(() => this._loadConfiguration(), config.EXTERNAL_CONFIG_RELOAD_INTERVAL),
                 BrowserDetector.isFirefox())
             ) {
-                const e = () => {
-                    browser.runtime.onUpdateAvailable.removeListener(e), this._installUpdate();
-                };
-                browser.runtime.onUpdateAvailable.addListener(e);
+                // Do nothing
             }
             this._isInitialized = !0;
         }
-    }
-    static _installUpdate() {
-        browser.tabs.query({}).then((e) => {
-            e.forEach((e) => {
-                if (!e.id) return;
-                browser.tabs.sendMessage(e.id, { command: "DESTROY" }).catch(console.error.bind(console));
-            });
-        }),
-            Tracker.trackEvent("Action", "pre_update"),
-            window.setTimeout(() => {
-                browser.runtime.reload();
-            }, 2e3);
     }
     static _assignToTestGroups() {
         EnvironmentAdapter.isProductionEnvironment();


### PR DESCRIPTION
This uses `browser.` APIs, which we are trying to remove for Chrome V3.