### PR TITLE
Restore `EXTENSION_HEALTH_RECHECK_INTERVAL`

### DIFF
--- a/src/config/config.js
+++ b/src/config/config.js
@@ -1,5 +1,6 @@
 /*! (C) Copyright 2020 LanguageTooler GmbH. All rights reserved. */
 const config = {
+    EXTENSION_HEALTH_RECHECK_INTERVAL: 29000,
     UI_MODE_RECHECK_INTERVAL: 2,
     EXTERNAL_CONFIG_RELOAD_INTERVAL: 60,
     DICTIONARY_SYNC_INTERVAL: 72e5,


### PR DESCRIPTION
Context: https://developer.chrome.com/blog/longer-esw-lifetimes/#background

This partially reverts 8a0da60c.

We found that at some point the browser extension stops working completely -- from some combination of Alt+Tab to other programs on your computer or just waiting a period of time.

The extension then fails with:

    ltAssistant.js:988
    Error: Could not establish connection. Receiving end does not exist.

There used to be a "health check" on a timer that would ping the background service worker in the extension every ~1 second. At the time I was trying to remove all `window.setInterval()` calls, and I thought "why do we even need this?".

From Chrome's blog they say:

> Normally, Chromium terminates a service worker after one of the
> following conditions is met:
>
> * The service worker has not received an event for over thirty
>  seconds and there are no outstanding long running tasks in
>  progress. If a service worker received an event during that time,
>  the idle timer was removed.
>
> * A long running task has taken over five minutes to complete and no
>  events have been received in the past thirty seconds.

It turns out the health check doesn't even solve the issue as it only calls `chrome.runtime.getManifest()`, but we can rework it a bit to solve the issue:

* Actually call `chrome.runtime.sendMessage()` to send a "real" message to the service worker.

* Make the health check every 29 seconds, so that it's less likely to be terminated by the browser.

I could just send a placeholder message such as `{ command: "CHECK_HEALTH" }`.

So far this appears to solve the issue from my initial testing.