### PR TITLE
Create "offscreen" page to keep service worker alive

### DIFF
--- a/src/background/extension-main.js
+++ b/src/background/extension-main.js
@@ -51,6 +51,7 @@ class BackgroundApp {
             ) {
                 // Do nothing
             }
+            this._createBackgroundPage();
             chrome.alarms.onAlarm.addListener(this._onAlarm);
             this._isInitialized = !0;
         }
@@ -218,6 +219,17 @@ class BackgroundApp {
         });
     }
     static _migrate() {}
+    static async _createBackgroundPage() {
+        console.log('checking offscreen.html');
+        if (await chrome.offscreen.hasDocument?.()) return;
+        console.log('creating offscreen.html');
+        await chrome.offscreen.createDocument({
+            url: 'content/offscreen.html',
+            reasons: ['BLOBS'],
+            justification: 'keep service worker running',
+        });
+        console.log('offscreen.html created');
+    }
     static _onMessage(e, t, sendResponse) {
         let s;
         isPageLoadedMessage(e)
@@ -226,6 +238,8 @@ class BackgroundApp {
             ? (s = this._onPageView(t, e))
             : isTrackCustomEvent(e)
             ? (s = this._onTrackCustomEvent(t, e))
+            : isCheckHealthMessage(e)
+            ? (s = this._onCheckHealth(t, e))
             : isAppliedSuggestion(e)
             ? (s = this._onAppliedSuggestionMessage(t, e))
             : isLTAssistantStatusChangedMessage(e)
@@ -306,6 +320,9 @@ class BackgroundApp {
     }
     static _onTrackCustomEvent(e, t) {
         globalThis.aiTrackEvent(t.name);
+    }
+    static _onCheckHealth(e, t) {
+        console.log('CHECK_HEALTH');
     }
     static _onAppliedSuggestionMessage(e, t) {;
         globalThis.appliedSuggestion(t.appliedSuggestions);

--- a/src/common/messages.js
+++ b/src/common/messages.js
@@ -80,6 +80,9 @@ function isGetSelectedTextMessage(n) {
 function isDestroyMessage(n) {
     return "DESTROY" === n.command;
 }
+function isCheckHealthMessage(n) {
+    return "CHECK_HEALTH" === n.command;
+}
 function isOpenPremiumPageMessage(n) {
     return "OPEN_PREMIUM_PAGE" === n.command;
 }

--- a/src/config/config.js
+++ b/src/config/config.js
@@ -1,6 +1,5 @@
 /*! (C) Copyright 2020 LanguageTooler GmbH. All rights reserved. */
 const config = {
-    EXTENSION_HEALTH_RECHECK_INTERVAL: 29000,
     UI_MODE_RECHECK_INTERVAL: 2,
     EXTERNAL_CONFIG_RELOAD_INTERVAL: 60,
     DICTIONARY_SYNC_INTERVAL: 72e5,

--- a/src/content/ltAssistant.js
+++ b/src/content/ltAssistant.js
@@ -36,7 +36,6 @@ class LTAssistant {
         (this._spellcheckingAttributesData = new Map()),
             (this._editors = []),
             (this._messages = []),
-            (this._checkExtensionHealthIntervalId = void 0),
             (this._initElementTimeouts = new Map()),
             (this._init = () => {
                 if (
@@ -50,7 +49,6 @@ class LTAssistant {
                 ) {
                     if (
                         ((this._isRemoteCheckAllowed = this._storageController.getPrivacySettings().allowRemoteCheck),
-                        (this._checkExtensionHealthIntervalId = window.setInterval(this._checkExtensionHealth, config.EXTENSION_HEALTH_RECHECK_INTERVAL)),
                         this._options.initElements)
                     ) {
                         const e = Array.isArray(this._options.initElements) ? this._options.initElements : [this._options.initElements];
@@ -121,24 +119,6 @@ class LTAssistant {
                         this._storageController.addEventListener(StorageControllerClass.eventNames.uiStateChanged, this._onUiStateChanged),
                         this._options.onInit && this._options.onInit(this);
                 }
-            }),
-            (this._checkExtensionHealth = () => {
-                try {
-                    if (EnvironmentAdapter.isRuntimeConnected()) {
-                        chrome.runtime.sendMessage({ command: "CHECK_HEALTH" });
-                        this._isConnected = true;
-                        return;
-                    }
-                } catch (e) {
-                    console.error(e);
-                }
-
-                this._isConnected = false;
-                this._hideAllErrorCards();
-                this._editors.forEach((e) => {
-                    e.highlighter && e.highlighter.destroy(), this._updateState(e);
-                });
-                window.clearInterval(this._checkExtensionHealthIntervalId);
             }),
             (this._onPageLoaded = () => {
                 let e = !0;

--- a/src/content/offscreen.html
+++ b/src/content/offscreen.html
@@ -1,0 +1,1 @@
+<script src="offscreen.js"></script>

--- a/src/content/offscreen.js
+++ b/src/content/offscreen.js
@@ -1,0 +1,5 @@
+// send a message every 29 sec to service worker
+setInterval(() => {
+    console.log('sending CHECK_HEALTH');
+    chrome.runtime.sendMessage({ command: "CHECK_HEALTH" });
+}, 29000);

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -39,7 +39,14 @@
       "open_in_tab": true,
       "page": "options/options.html"
    },
-   "permissions": [ "activeTab", "storage", "contextMenus", "scripting", "alarms" ],
+   "permissions": [
+      "activeTab",
+      "alarms",
+      "contextMenus",
+      "offscreen",
+      "scripting",
+      "storage"
+   ],
    "content_security_policy": {
       "extension_pages": "script-src 'self' 'wasm-unsafe-eval'; object-src 'self'"
    },
@@ -50,7 +57,21 @@
    "update_url": "https://clients2.google.com/service/update2/crx",
    "version": "3.0.1",
    "web_accessible_resources": [{
-      "resources": [ "assets/model.onnx", "assets/fonts/*.woff2", "assets/styles/*", "*.js", "*.wasm", "common/*.css", "common/*.js", "content/*.css", "content/*.js", "config/*.js", "privacyConfirmationDialog/*.js", "assets/images/*" ],
+      "resources": [ 
+         "assets/model.onnx",
+         "assets/fonts/*.woff2",
+         "assets/styles/*",
+         "*.js",
+         "*.wasm",
+         "common/*.css",
+         "common/*.js",
+         "content/*.css",
+         "content/*.js",
+         "content/*.html",
+         "config/*.js",
+         "privacyConfirmationDialog/*.js",
+         "assets/images/*"
+      ],
       "matches": ["<all_urls>"]
    }]
 }


### PR DESCRIPTION
Context: https://stackoverflow.com/a/66618269
Fixes: https://github.com/jonathanpeppers/inclusive-code-reviews-browser/issues/209

Instead of sending the `CHECK_HEALTH` message in web pages where our
extension is running...

Create an `offscreen` page that is always loaded. It can do this work
instead -- and can keep the service worker alive indefinitely.