### PR TITLE
Attempt to keep extension alive

### DIFF
--- a/src/background/extension-main.js
+++ b/src/background/extension-main.js
@@ -225,7 +225,7 @@ class BackgroundApp {
         console.log('creating offscreen.html');
         await chrome.offscreen.createDocument({
             url: 'content/offscreen.html',
-            reasons: ['BLOBS'],
+            reasons: [chrome.offscreen.Reason.WORKERS || chrome.offscreen.Reason.BLOBS],
             justification: 'keep service worker running',
         });
         console.log('offscreen.html created');

--- a/src/content/offscreen.js
+++ b/src/content/offscreen.js
@@ -1,5 +1,5 @@
-// send a message every 29 sec to service worker
+// send a message every 20 sec to service worker
 setInterval(() => {
     console.log('sending CHECK_HEALTH');
     chrome.runtime.sendMessage({ command: "CHECK_HEALTH" });
-}, 29000);
+}, 20000);


### PR DESCRIPTION
Context: https://github.com/jonathanpeppers/inclusive-code-reviews-browser/issues/209
Context: https://developer.chrome.com/docs/extensions/reference/offscreen/#type-Reason
Context: https://groups.google.com/a/chromium.org/g/chromium-extensions/c/No9agH_T3XU

Build 3.0.1 eventually started having issue #209 again after about a week of usage.

When in a broken state:

* edge://extensions page shows the "Service Worker (inactive)"

* The offscreen page is just *gone*

* Calling `chrome.runtime.reload()` in the console of the service worker fixes everything.

* You may need to refresh webpages after as well

So going to try two things:

* 20s timer instead of 29s

* Use `chrome.offscreen.Reason.WORKERS` and fallback to `BLOBS` in older versions of Chrome where this value may not exist.