### PR TITLE
[tests] skip openai tests on PRs from forks

### DIFF
--- a/test/openai.js
+++ b/test/openai.js
@@ -16,6 +16,13 @@ const openai = new OpenAIApi(new Configuration({
 }));
 
 describe('openai', () => {
+  // Just return if the key is not set.
+  // This would happen on a PR from a fork.
+  if (!openai_key) {
+    console.warn("Skipping openai tests, key not set.");
+    return;
+  }
+
   it('simple prompt', async () => {
     const response = await openai.createCompletion({
       model: 'text-davinci-003',


### PR DESCRIPTION
If someone runs the tests locally without setting up `secrets.js` or they open a PR from a fork -- all the openai tests would fail because the API key is missing.

Let's just skip those tests and write to the console if this happens.