### PR TITLE
Ignore trailing whitespace for length underlined

### DIFF
--- a/src-packed/textAnalytics.js
+++ b/src-packed/textAnalytics.js
@@ -151,6 +151,10 @@ export async function analyzeSentiment(ort, sentences) {
             importance: new ort.Tensor('float32', [''], [1,1]),
         })
         const result = results['PredictedLabel.output'].data[0];
+
+        // Trim any trailing spaces for the length used
+        const trimmedText =  text.trimEnd();
+
         sentiment.sentences.push({
             text: text,
             sentiment: result === '1' ? 'negative' : 'neutral',
@@ -159,7 +163,7 @@ export async function analyzeSentiment(ort, sentences) {
                 neutral: results['Score.output'].data[0],
             },
             offset: totalLength,
-            length: text.length,
+            length: trimmedText.length,
         });
         totalLength += text.length;
     }

--- a/src-packed/validator.js
+++ b/src-packed/validator.js
@@ -35,7 +35,7 @@ export async function getMatches(ort, text, matches) {
         });
     });
 
-    // TextAnalytics API
+    // Calls our ML model
     const result = await textAnalytics.analyzeSentiment(ort, text);
     if (result.error !== undefined) {
         console.log(result.error);

--- a/test/textAnalytics.js
+++ b/test/textAnalytics.js
@@ -47,7 +47,7 @@ This code is stupid.`
         var sentence = result.sentences[result.sentences.length - 1];
         expect(sentence.sentiment).to.be.equal("negative");
         expect(sentence.offset).to.be.equal(text1.length);
-        expect(sentence.length).to.be.equal(text2.length);
+        expect(sentence.length).to.be.equal(text2.length - 1); // \n is trimmed
     });
 
     it('Indented code blocks negative', async () => {
@@ -62,7 +62,7 @@ This code is stupid.`
         var sentence = result.sentences[0];
         expect(sentence.sentiment).to.be.equal("negative");
         expect(sentence.offset).to.be.equal(0);
-        expect(sentence.length).to.be.equal(text1.length);
+        expect(sentence.length).to.be.equal(text1.length - 1); // \n is trimmed
     });
 
     it('Preprocess 1', () => {

--- a/test/validator.js
+++ b/test/validator.js
@@ -96,4 +96,14 @@ describe('validator', () => {
         expect(matches[0].shortMessage).to.be.equal("Negative sentiment");
         expect(matches[1].shortMessage).to.be.equal("Comment is brief");
     });
+
+    it('Two sentences', async () => {
+        var matches = [];
+        var bad = 'This is bad.';
+        await client.getMatches(ort, bad + ' This is good.', matches);
+        expect(matches.length).to.be.equal(1);
+        var match = matches[0];
+        expect(match.offset).to.be.equal(0);
+        expect(match.length).to.be.equal(bad.length);
+    });
 });


### PR DESCRIPTION
Fixes: https://github.com/jonathanpeppers/inclusive-code-reviews-browser/issues/238

This fixes cases like:

    This is bad. This is good.

Where it used to underline the blank space after "This is bad. ".

Now it stops the underline at the `.`.