### PR TITLE
Allow V3 extension to "wake up" appropriately

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -1,8 +1,12 @@
-self.oninstall = () => {
-    // These were the order of V2 background.scripts
-    try {
-        importScripts("packed.js", "config/config.js", "common/browserDetector.js", "common/utils.js", "common/eventBus.js", "common/messages.js", "common/i18nManager.js", "common/extensioni18nManager.js", "common/languageManager.js", "common/storageController.js", "common/extensionStorageController.js", "common/environmentAdapter.js", "common/extensionEnvironmentAdapter.js", "common/extension-init.js", "common/tracker.js", "background/graphemeSplitter.js", "background/validator.js", "background/dictionarySync.js", "background/synonyms.js", "background/extension-main.js");
-    } catch (e) {
-        console.error(e);
-    }
-};
+console.log('service worker loaded');
+
+// These were the order of V2 background.scripts
+try {
+    importScripts("packed.js", "config/config.js", "common/browserDetector.js", "common/utils.js", "common/eventBus.js", "common/messages.js", "common/i18nManager.js", "common/extensioni18nManager.js", "common/languageManager.js", "common/storageController.js", "common/extensionStorageController.js", "common/environmentAdapter.js", "common/extensionEnvironmentAdapter.js", "common/extension-init.js", "common/tracker.js", "background/graphemeSplitter.js", "background/validator.js", "background/dictionarySync.js", "background/synonyms.js", "background/extension-main.js");
+} catch (e) {
+    console.error(e);
+}
+
+addEventListener('activate', () => {
+    console.log('service worker activated');
+});


### PR DESCRIPTION
Context: https://github.com/jonathanpeppers/inclusive-code-reviews-browser/pull/285

This is a smaller patch that also seems to fix the general problem here that exists for the Chrome V3 extension (on Chrome store):

1. Extension is working.

2. At some point Chrome "stops" the background service worker.

3. Extension no longer works until you click the "Restart" button in the edge://extensions page.

One problem here was we loaded all the scripts in `self.oninstall`, where we could just load them directly instead. This was basically only making the extension work for a period of time after it was initially installed.

You can test this behavior with the "Stop" button on this page:

    edge://serviceworker-internals/?devtools