### PR TITLE
Adjust FrequencyPenalty hyperparameter

### DIFF
--- a/src-packed/validator.js
+++ b/src-packed/validator.js
@@ -33,6 +33,8 @@ async function getOpenAISuggestions(sentence, matches) {
         ],
         // 0 accurate, 1 creative
         "temperature": 0.5,
+        // prevent the model from repeating itself without sacrificing quality of response
+        "frequencyPenalty": 1.0,
         "maxTokens": 800,
         "enableJsonMode": true
     };


### PR DESCRIPTION
FrequencyPenalty helps safeguard against the model repeating itself. By setting the value to 1.0 in its available range of -2.0 to 2.0, we can help minimize repetition while also maintaining the quality of responses returned.

Refs: 
- https://learn.microsoft.com/en-us/dotnet/api/azure.ai.openai.chatcompletionsoptions.frequencypenalty?view=azure-dotnet-preview
- https://platform.openai.com/docs/guides/text-generation/parameter-details