### PR TITLE
[npm] remove `chrome-types`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
             "version": "3.1.0",
             "dependencies": {
                 "@microsoft/applicationinsights-web": "^3.0.7",
-                "chrome-types": "^0.1.246",
                 "onnxruntime-web": "^1.16.3",
                 "webpack": "^5.89.0"
             },
@@ -3581,11 +3580,6 @@
             "engines": {
                 "node": ">=6.0"
             }
-        },
-        "node_modules/chrome-types": {
-            "version": "0.1.246",
-            "resolved": "https://registry.npmjs.org/chrome-types/-/chrome-types-0.1.246.tgz",
-            "integrity": "sha512-nX4M3ISvRnx/Dt3fdfTjLQaCiWwKoVUc+eaEjmURTR+47YJ5E82MQozFOsqV/U4QG+4+hNHdAwj53NtBGOitUw=="
         },
         "node_modules/class-utils": {
             "version": "0.3.6",
@@ -14763,11 +14757,6 @@
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.3.tgz",
             "integrity": "sha512-p3KULyQg4S7NIHixdwbGX+nFHkoBiA4YQmyWtjb8XngSKV124nJmRysgAeujbUVb15vh+RvFUfCPqU7rXk+hZg=="
-        },
-        "chrome-types": {
-            "version": "0.1.246",
-            "resolved": "https://registry.npmjs.org/chrome-types/-/chrome-types-0.1.246.tgz",
-            "integrity": "sha512-nX4M3ISvRnx/Dt3fdfTjLQaCiWwKoVUc+eaEjmURTR+47YJ5E82MQozFOsqV/U4QG+4+hNHdAwj53NtBGOitUw=="
         },
         "class-utils": {
             "version": "0.3.6",

--- a/package.json
+++ b/package.json
@@ -27,12 +27,12 @@
         "test/**/*"
     ],
     "devDependencies": {
+        "@types/chai": "^4.3.11",
+        "@types/chrome": "^0.0.256",
+        "@types/mocha": "^10.0.6",
         "extension-cli": "^1.2.4",
         "global": "^4.3.2",
-        "onnxruntime-node": "^1.16.3",
-        "@types/chrome": "^0.0.256",
-        "@types/chai" : "^4.3.11",
-        "@types/mocha": "^10.0.6"
+        "onnxruntime-node": "^1.16.3"
     },
     "xtdocs": {
         "source": {
@@ -64,7 +64,6 @@
     },
     "dependencies": {
         "@microsoft/applicationinsights-web": "^3.0.7",
-        "chrome-types": "^0.1.246",
         "onnxruntime-web": "^1.16.3",
         "webpack": "^5.89.0"
     },


### PR DESCRIPTION
I think we should be using `@types/chrome` instead here.