### PR TITLE
Fix error with `appinsights`

### DIFF
--- a/src-packed/validator.js
+++ b/src-packed/validator.js
@@ -80,7 +80,6 @@ export async function getOpenAISuggestions(sentence) {
 
 export async function getMatches(ort, text, matches) {
     ort.env.wasm.numThreads = 1;
-    loadAppInsights();
 
     // Suggestions, based on a dictionary
     suggestions.getSuggestions(text).forEach(suggestion => {
@@ -177,7 +176,6 @@ export function clearState() {
 // Sends the 'appliedSuggestion' event and clears the state of 'pastErrorCount'
 export function appliedSuggestion(appliedSuggestions) {
     clearState();
-    loadAppInsights();
     getAppInsights().trackEvent('appliedSuggestion', { total: appliedSuggestions });
 }
 


### PR DESCRIPTION
I think this would happen if the first call to send telemetry was the "Ask an AI" button:

    Uncaught (in promise) TypeError: Cannot read properties of null (reading 'trackEvent')
        at packed.js:1:719591
        at BackgroundApp._onAskAnAIMessage (extension-main.js:405:27)
        at BackgroundApp._onMessage (extension-main.js:242:25)

I changed everything to do:

    --appinsights.trackEvent('askAI');
    ++getAppInsights().trackEvent('askAI');

So they all check if `appinsights` is null.