### PR TITLE
[manifest] remove `update_url` for Edge

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -52,7 +52,6 @@
    "storage": {
       "managed_schema": "managed_settings.json"
    },
-   "update_url": "https://clients2.google.com/service/update2/crx",
    "version": "3.1.0",
    "web_accessible_resources": [{
       "resources": [ 


### PR DESCRIPTION
I tried to submit our first Chrome V3 version of this extension to the Edge store and it says:

    Your package failed certification. Make corrections and certify again.

    The following checks failed:
    Package acceptance validation error:
    The manifest shouldn't contain update_url field.
    Error code: update_url: https://clients2.google.com/service/update2/crx Line: 55 Column: 66

Removing this line from `manifest.json` to try again.