### PR TITLE
[suggestions] hangs -> freezes

### DIFF
--- a/src-packed/suggestions.js
+++ b/src-packed/suggestions.js
@@ -64,6 +64,7 @@ const allReplacements = {
     "dumb-down": ["simplify"],
     // violent
     "hang": ["freeze"],
+    "hangs": ["freezes"],
     "hanging": ["frozen", "stuck"],
     "hit": ["click", "tap", "run into"],
     "crushing it": ["elevating", "exceeding expectations", "excelling"],


### PR DESCRIPTION
I noticed the extension underlines "hang", but not "hangs".