### PR TITLE
Add telemetry to track suggestion popups

### DIFF
--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -89,6 +89,25 @@ We also report `customMeasurements` such as:
 
 The user clicked `Ask an AI for suggestions`.
 
+## requestSuggestionsPopup
+
+The user has clicked something that would present a popup of some sort with suggestions or a way to get suggestions.
+
+1. The user clicked the underlined text
+2. The user has clicked the bottom-left corner indicator
+
+We also report `customMeasurements` such as:
+
+```json
+{ "type": "inlineErrorCard" }
+```
+
+Or
+
+```json
+{ "type": "indicatorDialog" }
+```
+
 ## Queries
 
 These are just a list of Kusto queries for looking at the data:

--- a/src-packed/validator.js
+++ b/src-packed/validator.js
@@ -200,3 +200,4 @@ export function shouldReportManualFix(matches) {
 globalThis.getMatches = getMatches;
 globalThis.getOpenAISuggestions = getOpenAISuggestions;
 globalThis.appliedSuggestion = appliedSuggestion;
+globalThis.getAppInsights = getAppInsights;

--- a/src/content/ltAssistant.js
+++ b/src/content/ltAssistant.js
@@ -1191,6 +1191,7 @@ class LTAssistant {
     }
     _showErrorCard(e, t, r) {
         chrome.runtime.sendMessage({ command: "TRACK_PAGE_VIEW", location: { name: document.title, uri: window.location.href } });
+        globalThis.getAppInsights().trackEvent('requestSuggestionsPopup', { type: 'inlineErrorCard' });
         const i = this._storageController.getManagedSettings(),
             o = {
                 disableIgnoringRule: void 0 !== this._options.disableRuleIgnore ? this._options.disableRuleIgnore : i.disableIgnoredRules,
@@ -1244,6 +1245,7 @@ class LTAssistant {
     }
     _showDialog(e) {
         if (!e.toolbar) return;
+        globalThis.getAppInsights().trackEvent('requestSuggestionsPopup', { type: 'indicatorDialog' });
         const t = e.language && e.language.code,
             r = new TextStatistics(e.validatedText.originalText),
             i = new TextScore().calculateTextScore(r.getAllWords().length, e.errors, e.premiumErrors, e.pickyErrors),


### PR DESCRIPTION
This change adds telemetry for when the user requests the various suggestion popups, such as the inline error card or the corner indicator dialog.

This telemetry will show how the user is getting suggestions - if at all.

Fixes #328