### PR TITLE
[tests] fix failing CI: `textAnalytics.js Negative`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
             "version": "3.1.0",
             "dependencies": {
                 "@microsoft/applicationinsights-web": "^3.0.7",
-                "onnxruntime-web": "^1.17.0",
+                "onnxruntime-web": "^1.16.3",
                 "webpack": "^5.90.1"
             },
             "devDependencies": {
@@ -8647,8 +8647,7 @@
         "node_modules/onnxruntime-common": {
             "version": "1.16.3",
             "resolved": "https://registry.npmjs.org/onnxruntime-common/-/onnxruntime-common-1.16.3.tgz",
-            "integrity": "sha512-ZZfFzEqBf6YIGwB9PtBLESHI53jMXA+/hn+ACVUbEfPuK2xI5vMGpLPn+idpwCmHsKJNRzRwqV12K+6TQj6tug==",
-            "dev": true
+            "integrity": "sha512-ZZfFzEqBf6YIGwB9PtBLESHI53jMXA+/hn+ACVUbEfPuK2xI5vMGpLPn+idpwCmHsKJNRzRwqV12K+6TQj6tug=="
         },
         "node_modules/onnxruntime-node": {
             "version": "1.17.0",
@@ -8671,22 +8670,17 @@
             "dev": true
         },
         "node_modules/onnxruntime-web": {
-            "version": "1.17.0",
-            "resolved": "https://registry.npmjs.org/onnxruntime-web/-/onnxruntime-web-1.17.0.tgz",
-            "integrity": "sha512-O5IZrnJ4ABMmgttdcuG/y3z8WT0zMieCeh/4Eq3lf3CeLwKLoPno38WbAvDiRUkfKjXUyu2mw532YIuGi61YJA==",
+            "version": "1.16.3",
+            "resolved": "https://registry.npmjs.org/onnxruntime-web/-/onnxruntime-web-1.16.3.tgz",
+            "integrity": "sha512-8O1xCG/RcNQNYYWvdiQJSNpncVg78OVOFeV6MYs/jx++/b12oje8gYUzKqz9wR/sXiX/8TCvdyHgEjj5gQGKUg==",
             "dependencies": {
                 "flatbuffers": "^1.12.0",
                 "guid-typescript": "^1.0.9",
                 "long": "^5.2.3",
-                "onnxruntime-common": "1.17.0",
+                "onnxruntime-common": "~1.16.3",
                 "platform": "^1.3.6",
                 "protobufjs": "^7.2.4"
             }
-        },
-        "node_modules/onnxruntime-web/node_modules/onnxruntime-common": {
-            "version": "1.17.0",
-            "resolved": "https://registry.npmjs.org/onnxruntime-common/-/onnxruntime-common-1.17.0.tgz",
-            "integrity": "sha512-Vq1remJbCPITjDMJ04DA7AklUTnbYUp4vbnm6iL7ukSt+7VErH0NGYfekRSTjxxurEtX7w41PFfnQlE6msjPJw=="
         },
         "node_modules/optionator": {
             "version": "0.9.1",
@@ -18795,8 +18789,7 @@
         "onnxruntime-common": {
             "version": "1.16.3",
             "resolved": "https://registry.npmjs.org/onnxruntime-common/-/onnxruntime-common-1.16.3.tgz",
-            "integrity": "sha512-ZZfFzEqBf6YIGwB9PtBLESHI53jMXA+/hn+ACVUbEfPuK2xI5vMGpLPn+idpwCmHsKJNRzRwqV12K+6TQj6tug==",
-            "dev": true
+            "integrity": "sha512-ZZfFzEqBf6YIGwB9PtBLESHI53jMXA+/hn+ACVUbEfPuK2xI5vMGpLPn+idpwCmHsKJNRzRwqV12K+6TQj6tug=="
         },
         "onnxruntime-node": {
             "version": "1.17.0",
@@ -18816,23 +18809,16 @@
             }
         },
         "onnxruntime-web": {
-            "version": "1.17.0",
-            "resolved": "https://registry.npmjs.org/onnxruntime-web/-/onnxruntime-web-1.17.0.tgz",
-            "integrity": "sha512-O5IZrnJ4ABMmgttdcuG/y3z8WT0zMieCeh/4Eq3lf3CeLwKLoPno38WbAvDiRUkfKjXUyu2mw532YIuGi61YJA==",
+            "version": "1.16.3",
+            "resolved": "https://registry.npmjs.org/onnxruntime-web/-/onnxruntime-web-1.16.3.tgz",
+            "integrity": "sha512-8O1xCG/RcNQNYYWvdiQJSNpncVg78OVOFeV6MYs/jx++/b12oje8gYUzKqz9wR/sXiX/8TCvdyHgEjj5gQGKUg==",
             "requires": {
                 "flatbuffers": "^1.12.0",
                 "guid-typescript": "^1.0.9",
                 "long": "^5.2.3",
-                "onnxruntime-common": "1.17.0",
+                "onnxruntime-common": "~1.16.3",
                 "platform": "^1.3.6",
                 "protobufjs": "^7.2.4"
-            },
-            "dependencies": {
-                "onnxruntime-common": {
-                    "version": "1.17.0",
-                    "resolved": "https://registry.npmjs.org/onnxruntime-common/-/onnxruntime-common-1.17.0.tgz",
-                    "integrity": "sha512-Vq1remJbCPITjDMJ04DA7AklUTnbYUp4vbnm6iL7ukSt+7VErH0NGYfekRSTjxxurEtX7w41PFfnQlE6msjPJw=="
-                }
             }
         },
         "optionator": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
                 "@types/mocha": "^10.0.6",
                 "extension-cli": "^1.2.4",
                 "global": "^4.3.2",
-                "onnxruntime-node": "^1.17.0"
+                "onnxruntime-node": "^1.16.3"
             }
         },
         "node_modules/@ampproject/remapping": {
@@ -8650,9 +8650,9 @@
             "integrity": "sha512-ZZfFzEqBf6YIGwB9PtBLESHI53jMXA+/hn+ACVUbEfPuK2xI5vMGpLPn+idpwCmHsKJNRzRwqV12K+6TQj6tug=="
         },
         "node_modules/onnxruntime-node": {
-            "version": "1.17.0",
-            "resolved": "https://registry.npmjs.org/onnxruntime-node/-/onnxruntime-node-1.17.0.tgz",
-            "integrity": "sha512-pRxdqSP3a6wtiFVkVX1V3/gsEMwBRUA9D2oYmcN3cjF+j+ILS+SIY2L7KxdWapsG6z64i5rUn8ijFZdIvbojBg==",
+            "version": "1.16.3",
+            "resolved": "https://registry.npmjs.org/onnxruntime-node/-/onnxruntime-node-1.16.3.tgz",
+            "integrity": "sha512-6T2pjwg5ik74VnI1IXFzxvPAm2UCo+vNNsDGbMP+A2q6GZPMYai2pMA17g3YMUvgOZLwsjWBUwNIlP4QaVRFlA==",
             "dev": true,
             "os": [
                 "win32",
@@ -8660,14 +8660,8 @@
                 "linux"
             ],
             "dependencies": {
-                "onnxruntime-common": "1.17.0"
+                "onnxruntime-common": "~1.16.3"
             }
-        },
-        "node_modules/onnxruntime-node/node_modules/onnxruntime-common": {
-            "version": "1.17.0",
-            "resolved": "https://registry.npmjs.org/onnxruntime-common/-/onnxruntime-common-1.17.0.tgz",
-            "integrity": "sha512-Vq1remJbCPITjDMJ04DA7AklUTnbYUp4vbnm6iL7ukSt+7VErH0NGYfekRSTjxxurEtX7w41PFfnQlE6msjPJw==",
-            "dev": true
         },
         "node_modules/onnxruntime-web": {
             "version": "1.16.3",
@@ -18792,20 +18786,12 @@
             "integrity": "sha512-ZZfFzEqBf6YIGwB9PtBLESHI53jMXA+/hn+ACVUbEfPuK2xI5vMGpLPn+idpwCmHsKJNRzRwqV12K+6TQj6tug=="
         },
         "onnxruntime-node": {
-            "version": "1.17.0",
-            "resolved": "https://registry.npmjs.org/onnxruntime-node/-/onnxruntime-node-1.17.0.tgz",
-            "integrity": "sha512-pRxdqSP3a6wtiFVkVX1V3/gsEMwBRUA9D2oYmcN3cjF+j+ILS+SIY2L7KxdWapsG6z64i5rUn8ijFZdIvbojBg==",
+            "version": "1.16.3",
+            "resolved": "https://registry.npmjs.org/onnxruntime-node/-/onnxruntime-node-1.16.3.tgz",
+            "integrity": "sha512-6T2pjwg5ik74VnI1IXFzxvPAm2UCo+vNNsDGbMP+A2q6GZPMYai2pMA17g3YMUvgOZLwsjWBUwNIlP4QaVRFlA==",
             "dev": true,
             "requires": {
-                "onnxruntime-common": "1.17.0"
-            },
-            "dependencies": {
-                "onnxruntime-common": {
-                    "version": "1.17.0",
-                    "resolved": "https://registry.npmjs.org/onnxruntime-common/-/onnxruntime-common-1.17.0.tgz",
-                    "integrity": "sha512-Vq1remJbCPITjDMJ04DA7AklUTnbYUp4vbnm6iL7ukSt+7VErH0NGYfekRSTjxxurEtX7w41PFfnQlE6msjPJw==",
-                    "dev": true
-                }
+                "onnxruntime-common": "~1.16.3"
             }
         },
         "onnxruntime-web": {

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     },
     "dependencies": {
         "@microsoft/applicationinsights-web": "^3.0.7",
-        "onnxruntime-web": "^1.17.0",
+        "onnxruntime-web": "^1.16.3",
         "webpack": "^5.90.1"
     },
     "overrides": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
         "@types/mocha": "^10.0.6",
         "extension-cli": "^1.2.4",
         "global": "^4.3.2",
-        "onnxruntime-node": "^1.17.0"
+        "onnxruntime-node": "^1.16.3"
     },
     "xtdocs": {
         "source": {

--- a/src-packed/textAnalytics.js
+++ b/src-packed/textAnalytics.js
@@ -127,9 +127,13 @@ export function splitIntoSentences(text) {
 
 var session;
 
-export async function analyzeSentiment(ort, sentences) {
+export async function initialize(ort) {
     if (session == null)
         session = await ort.InferenceSession.create('./assets/model.onnx');
+}
+
+export async function analyzeSentiment(ort, sentences) {
+    await initialize(ort);
 
     var shouldPreprocess = true;
 

--- a/test/textAnalytics.js
+++ b/test/textAnalytics.js
@@ -6,7 +6,7 @@ describe('textAnalytics', () => {
     // NOTE: This appears to be taking a while on CI, sometimes
     it('Initialize', async () => {
         await client.initialize(ort);
-    }).timeout(20000);
+    }).timeout(60000);
 
     it('Negative', async () => {
         const result = await client.analyzeSentiment(ort, "This is terrible!");

--- a/test/textAnalytics.js
+++ b/test/textAnalytics.js
@@ -6,7 +6,7 @@ describe('textAnalytics', () => {
     // NOTE: This appears to be taking a while on CI, sometimes
     it('Initialize', async () => {
         await client.initialize(ort);
-    }).timeout(60000);
+    }).timeout(20000);
 
     it('Negative', async () => {
         const result = await client.analyzeSentiment(ort, "This is terrible!");

--- a/test/textAnalytics.js
+++ b/test/textAnalytics.js
@@ -3,6 +3,11 @@ import * as ort from 'onnxruntime-node';
 describe('textAnalytics', () => {
     const client = require('../src-packed/textAnalytics');
 
+    // NOTE: This appears to be taking a while on CI, sometimes
+    it('Initialize', async () => {
+        await client.initialize(ort);
+    }).timeout(20000);
+
     it('Negative', async () => {
         const result = await client.analyzeSentiment(ort, "This is terrible!");
         expect(result.sentences[0].sentiment).to.be.equal("negative");


### PR DESCRIPTION
Fixes the error:

  1) textAnalytics
    Negative:
  Error: Timeout of 2000ms exceeded. For async tests and hooks, ensure "done()" is called; if returning a Promise, ensure it resolves. (/home/runner/work/inclusive-code-reviews-browser/inclusive-code-reviews-browser/test/textAnalytics.js)

It appears that the onnxruntime is slow on the first call.

I added a method to explicitly initialize and made this the first test with a timeout.