### PR TITLE
Disable clicking the second popup

### DIFF
--- a/assets/locales/en/messages.json
+++ b/assets/locales/en/messages.json
@@ -1119,7 +1119,7 @@
    },
    "statusIconToolTip": {
       "description": "Shown when hovering over the status icon (not the toolbar one)",
-      "message": "Inclusive Comments Check"
+      "message": "Inclusive Code Comments"
    },
    "suggestionError": {
       "description": "Type of error (spelling error, style suggestion, grammar error, ...)",

--- a/src/content/styles/styles.css
+++ b/src/content/styles/styles.css
@@ -1086,7 +1086,7 @@ html:not([data-lt-script-installed]):not(.__lt-dummy-1):not(.__lt-dummy-2):not(.
     border: none !important;
     border-radius: 50% !important;
     user-select: none !important;
-    cursor: pointer !important;
+    /*cursor: pointer !important;*/
     transform-origin: right bottom !important;
     transition: transform 0.2s !important; }
   html:not([data-lt-script-installed]):not(.__lt-dummy-1):not(.__lt-dummy-2):not(.__lt-dummy-3):not(.__lt-dummy-4):not(.__lt-dummy-5):not(.__lt-dummy-6) lt-toolbar .lt-toolbar__status-icon {

--- a/src/content/toolbar.js
+++ b/src/content/toolbar.js
@@ -197,15 +197,17 @@ class Toolbar {
         const e = t.target;
         if (![this._controls.wrapper, this._controls.statusIcon, this._controls.premiumIcon].includes(e)) return;
         t.stopImmediatePropagation();
-        const s = { toolbar: this };
-        if (this._state.validationStatus === VALIDATION_STATUS.PERMISSION_REQUIRED) dispatchCustomEvent(document, Toolbar.eventNames.permissionRequiredIconClicked, s);
-        else if (this._state.validationStatus === VALIDATION_STATUS.FAILED) Tracker.trackEvent("Action", "dialog:opened", "FAILED"), dispatchCustomEvent(document, Toolbar.eventNames.toggleDialog, s);
-        else {
-            let t = this._state.validationStatus;
-            t === VALIDATION_STATUS.COMPLETED && this._state.errorsCount > 0 ? (t = "HAS_ERRORS") : t === VALIDATION_STATUS.COMPLETED && this._state.premiumErrorsCount > 0 && (t = "HAS_ONLY_PREMIUM_ERRORS"),
-                Tracker.trackEvent("Action", "dialog:opened", t),
-                dispatchCustomEvent(document, Toolbar.eventNames.toggleDialog, s);
-        }
+        // Commented out the code below to prevent dialog from opening, for now.
+        // The dialog needs work to be more useful.
+        // const s = { toolbar: this };
+        // if (this._state.validationStatus === VALIDATION_STATUS.PERMISSION_REQUIRED) dispatchCustomEvent(document, Toolbar.eventNames.permissionRequiredIconClicked, s);
+        // else if (this._state.validationStatus === VALIDATION_STATUS.FAILED) Tracker.trackEvent("Action", "dialog:opened", "FAILED"), dispatchCustomEvent(document, Toolbar.eventNames.toggleDialog, s);
+        // else {
+        //     let t = this._state.validationStatus;
+        //     t === VALIDATION_STATUS.COMPLETED && this._state.errorsCount > 0 ? (t = "HAS_ERRORS") : t === VALIDATION_STATUS.COMPLETED && this._state.premiumErrorsCount > 0 && (t = "HAS_ONLY_PREMIUM_ERRORS"),
+        //         Tracker.trackEvent("Action", "dialog:opened", t),
+        //         dispatchCustomEvent(document, Toolbar.eventNames.toggleDialog, s);
+        // }
     }
     updateState(t) {
         if (isSameObjects(this._stateForComparison, t)) return;


### PR DESCRIPTION
We generally click on the underlined word in text, but there is a "second popup" that is not fully functional and a bit odd:

* It shows negative sentiment with text strikethrough, which is confusing.
* It has options to change language?!?
* It has options to dock the popup all over the web page.

There are also a couple issues opened, related:

* https://github.com/jonathanpeppers/inclusive-code-reviews-browser/issues/338
* https://github.com/jonathanpeppers/inclusive-code-reviews-browser/pull/329

For now, let's just disable the second popup? I also disabled the hover effect for the pointer and updated the tooltip text for this button.