### PR TITLE
Don't flag `/rebase` as "too short"

### DIFF
--- a/src-packed/validator.js
+++ b/src-packed/validator.js
@@ -146,14 +146,9 @@ export async function getMatches(ort, text, matches) {
 
 /*
     Contains a list of brief phrases that can be ignored.
-    Be conscientious when adding new items to this file, as we don't want to filter out generic words/phrases that could be improved with further explanation.
+    Be conscientious when adding new items, as we don't want to filter out generic words/phrases that could be improved with further explanation.
 */
-var ignorableBriefPhraseRegex = new RegExp(
-    "/azp run|" + 
-    "fixes #|" +
-    "implements #", 
-    "gi"
-);
+var ignorableBriefPhraseRegex = new RegExp('^\/|fixes #|implements #', 'i');
 
 // clears the state of 'pastErrorCount'
 export function clearState() {

--- a/test/validator.js
+++ b/test/validator.js
@@ -94,10 +94,13 @@ describe('validator', () => {
         expect(matches.length).to.be.equal(0);
     });
 
-    it('Brief text in ignore list no suggestion', async () => {
-        var matches = [];
-        await client.getMatches(ort, "Fixes #77", matches);
-        expect(matches.length).to.be.equal(0);
+    var phrases = [ 'Fixes #77', 'Implements #77', '/azp run', '/rebase', '@dependabot merge' ];
+    phrases.forEach(phrase => {
+        it('Brief text no suggestion ' + phrase, async () => {
+            var matches = [];
+            await client.getMatches(ort, phrase, matches);
+            expect(matches.length).to.be.equal(0, phrase + ' should not have suggestions');
+        });
     });
 
     it('Brief text but catches negative connotation first', async () => {


### PR DESCRIPTION
Fixes: https://github.com/jonathanpeppers/inclusive-code-reviews-browser/issues/320