### PR TITLE
Suggestions for "execute" and "execution"

### DIFF
--- a/src-packed/suggestions.js
+++ b/src-packed/suggestions.js
@@ -71,7 +71,8 @@ const allReplacements = {
     "killing it": ["elevating", "exceeding expectations", "excelling"],
     "kill": ["stop", "cancel"],
     "nuke": ["delete", "remove"],
-    "execute": ["start", "run"],
+    "execute": ["start", "run", "begin", "implement", "complete"],
+    "execution": ["runtime", "operation", "implementation", "completion"],
     // ageist
     "grandfather": ["flagship", "established", "rollover", "carryover", "classic"],
     "legacy": ["flagship", "established", "rollover", "carryover", "classic"],


### PR DESCRIPTION
Fixes: https://github.com/jonathanpeppers/inclusive-code-reviews-browser/issues/371

Just looking up the synonyms for "execution":

* noun as in *killing*

Made me think this is a good one to keep!

* noun as in *carrying out of a task*

I added more examples for `execution`, which could be commonly used in programming.