### PR TITLE
[telemetry] add `ai.user.id` to identify unique installs

### DIFF
--- a/src-packed/appinsights.js
+++ b/src-packed/appinsights.js
@@ -12,14 +12,30 @@ const appinsights = new ApplicationInsights({
     }
 });
 
+var appinsights_user_id = null;
+
 // Don't enable these in "unit test" mode
 if (!isTests) {
+    getUserId();
     appinsights.loadAppInsights();
     appinsights.addTelemetryInitializer(telemetryInitializer);
 }
 
+function getUserId() {
+    chrome.storage.sync.get('inclusive-code-reviews-userid', function(items) {
+        if (items.userid) {
+            appinsights_user_id = items.userid;
+        } else {
+            appinsights_user_id = self.crypto.randomUUID();
+            chrome.storage.sync.set({userid: appinsights_user_id});
+        }
+    });
+}
+
 export function telemetryInitializer (envelope) {
     envelope.tags["ai.application.ver"] = '3.1.2';
+    if (appinsights_user_id)
+        envelope.tags["ai.user.id"] = appinsights_user_id;
 
     // We don't want to report full URLs
     if (envelope.baseData.uri) {


### PR DESCRIPTION
Fixes: https://github.com/jonathanpeppers/inclusive-code-reviews-browser/issues/405

Store an anonymous `self.crypto.randomUUID()` value, we can use to just find out "unique installs" of the browser extension.

This used to work automatically by AppInsights, but it either broke when we moved to Chrome V3 or a dependabot update.

With this change I see in the network tab:

    ai.user.id : "ab57ffa4-f33f-46ee-b4fc-94da8fb6c5c5"

I see the same number throughout the session, and it's different if I uninstall and reinstall the extension.