### PR TITLE
[telemetry] pass appinsights user to CommentRewrite API

### DIFF
--- a/src-packed/appinsights.js
+++ b/src-packed/appinsights.js
@@ -16,12 +16,12 @@ var appinsights_user_id = null;
 
 // Don't enable these in "unit test" mode
 if (!isTests) {
-    getUserId();
+    retrieveUserId();
     appinsights.loadAppInsights();
     appinsights.addTelemetryInitializer(telemetryInitializer);
 }
 
-function getUserId() {
+function retrieveUserId() {
     chrome.storage.sync.get('inclusive-code-reviews-userid', function(items) {
         if (items.userid) {
             appinsights_user_id = items.userid;
@@ -30,6 +30,10 @@ function getUserId() {
             chrome.storage.sync.set({userid: appinsights_user_id});
         }
     });
+}
+
+export function getUserId() {
+    return appinsights_user_id;
 }
 
 export function telemetryInitializer (envelope) {

--- a/src-packed/validator.js
+++ b/src-packed/validator.js
@@ -17,7 +17,8 @@ function getAppInsights() {
 }
 
 export async function getOpenAISuggestions(sentence) {
-    getAppInsights().trackEvent('askAI');
+    var appinsights = getAppInsights();
+    appinsights.trackEvent('askAI');
 
     let request = {
         "comment": sentence.text,
@@ -36,7 +37,8 @@ export async function getOpenAISuggestions(sentence) {
     const response = await fetch(endpoint, {
         method: 'POST',
         headers: {
-            'Content-Type': 'application/json'
+            'Content-Type': 'application/json',
+            'X-AppInsights-UserId': appinsights.getUserId()
         },
         body: JSON.stringify(request),
     }).then(response => response.json());


### PR DESCRIPTION
So we can correlate requests for this service on the backend if needed.