### PR TITLE
remove external configuration load

### DIFF
--- a/src/background/extension-main.js
+++ b/src/background/extension-main.js
@@ -134,15 +134,7 @@ class BackgroundApp {
     }
     static _loadConfiguration() {
         this._storageController.onReady(() => {
-            this._storageController.isUsedCustomServer() ||
-                fetch(config.EXTERNAL_CONFIG_URL, { credentials: "omit" })
-                    .then((e) => e.json())
-                    .then((e) => {
-                        if (e.disabledSites && Array.isArray(e.disabledSites)) {
-                            const t = { unsupportedDomains: e.disabledSites };
-                            this._storageController.updateConfiguration(t);
-                        }
-                    });
+            this._storageController.isUsedCustomServer();
         });
     }
     static _onInstalled(e) {

--- a/src/background/extension-main.js
+++ b/src/background/extension-main.js
@@ -43,7 +43,6 @@ class BackgroundApp {
             chrome.runtime.onMessage.addListener(this._onMessage),
             DictionarySync.init(),
             this._updateIcon(),
-            this._loadConfiguration();
             this._isInitialized = !0;
         }
     }
@@ -131,11 +130,6 @@ class BackgroundApp {
     static _applyManagedSettings() {
         const { disablePrivacyConfirmation: e } = this._storageController.getManagedSettings();
         !0 === e && this._storageController.updatePrivacySettings({ allowRemoteCheck: !0 });
-    }
-    static _loadConfiguration() {
-        this._storageController.onReady(() => {
-            this._storageController.isUsedCustomServer();
-        });
     }
     static _onInstalled(e) {
         const { reason: t, previousVersion: a } = e;

--- a/src/config/config.js
+++ b/src/config/config.js
@@ -8,7 +8,6 @@ const config = {
     MAIN_SERVER_URL: "https://api.languagetool.org/v2",
     LOCAL_SERVER_URL: "http://localhost:8081/v2",
     FEEDBACK_SERVER_URL: "https://languagetool.org/send-feedback/",
-    EXTERNAL_CONFIG_URL: "https://languagetool.org/webextension_config.json",
     CLIENT_LOGIN_URL: "https://languagetool.org/client-login",
     SWITCH_TO_FALLBACK_SERVER_ERRORS: [502, 503, 504],
     MAIN_SERVER_RECHECK_INTERVAL: 18e5,


### PR DESCRIPTION
The upstream browser extension has a feature to load configuration from remote server. For ICR extension, this remote configuration server does not apply anymore. So, this PR is removing the remote configuration load part.

#Remove configuration server
https://languagetool.org/webextension_config.json
![image](https://github.com/user-attachments/assets/b11e03af-013a-4195-8fd9-f49ed4a2a521)
