### PR TITLE
All underlines are purple now

### DIFF
--- a/src-packed/validator.js
+++ b/src-packed/validator.js
@@ -1,7 +1,6 @@
 // packed/validator.js returns a data structure that background/validator.js expects
 
 // NOTE: These values were from the original extension, we can repurpose to display different colors
-const ISSUE_TYPE_YELLOW = "misspelling";
 const ISSUE_TYPE_PURPLE = "style";
 const NEGATIVE_SENTIMENT_THRESHOLD = 0.6;
 const suggestions = require('./suggestions');
@@ -79,7 +78,7 @@ export async function getMatches(ort, text, matches) {
             "shortMessage": "Negative word",
             "offset": suggestion.index,
             "length": suggestion.length,
-            "rule": { "id": "NON_STANDARD_WORD", "subId": "1", "description": "Negative word", "issueType": ISSUE_TYPE_YELLOW, "category": { "id": "TYPOS", "name": "Negative word" } },
+            "rule": { "id": "NON_STANDARD_WORD", "subId": "1", "description": "Negative word", "issueType": ISSUE_TYPE_PURPLE, "category": { "id": "TYPOS", "name": "Negative word" } },
             "replacements": suggestion.replacements,
             "type": { "typeName": "Other" },
             "ignoreForIncompleteSentence": false,
@@ -130,7 +129,7 @@ export async function getMatches(ort, text, matches) {
             "shortMessage": "Comment is brief",
             "offset": 0,
             "length": text.length,
-            "rule": { "id": "NON_STANDARD_WORD", "subId": "1", "description": "Negative word", "issueType": ISSUE_TYPE_YELLOW, "category": { "id": "TYPOS", "name": "Small text" } },
+            "rule": { "id": "NON_STANDARD_WORD", "subId": "1", "description": "Negative word", "issueType": ISSUE_TYPE_PURPLE, "category": { "id": "TYPOS", "name": "Small text" } },
             "replacements": [],
             "type": { "typeName": "Other" },
             "ignoreForIncompleteSentence": false,


### PR DESCRIPTION
Fixes: https://github.com/jonathanpeppers/inclusive-code-reviews-browser/issues/429

I think that gives a less of a "warning" vibe, as we are just suggesting better options.