### PR TITLE
Null check if getSettings() returns null

### DIFF
--- a/src/background/extension-main.js
+++ b/src/background/extension-main.js
@@ -320,7 +320,11 @@ class BackgroundApp {
         });
     }
     static _getPreferredLanguages(e) {
-        const { geoIpLanguages: t, motherTongue: a } = this._storageController.getSettings();
+        var settings = this._storageController.getSettings();
+        if (!settings) {
+            return LanguageManager.getUserLanguageCodes().push("en");
+        }
+        const { geoIpLanguages: t, motherTongue: a } = settings;
         let s = [];
         if ((a && s.push(a), e.tab)) {
             const t = this._extensionStates[e.tab.id];


### PR DESCRIPTION
Fixes: https://github.com/jonathanpeppers/inclusive-code-reviews-browser/issues/314

    Error in event handler: TypeError: Cannot destructure property 'geoIpLanguages' of 'this._storageController.getSettings(...)' as it is undefined. at BackgroundApp._getPreferredLanguages (chrome-extension://plmhdfocagbmlgnabhleebabidkfikfj/background/extension-main.js:337:33) at BackgroundApp._onValidateTextMessage (chrome-extension://plmhdfocagbmlgnabhleebabidkfikfj/background/extension-main.js:347:24) at BackgroundApp._onMessage (chrome-extension://plmhdfocagbmlgnabhleebabidkfikfj/background/extension-main.js:232:25)