### PR TITLE
Downgrade onxxruntime and webpack

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -117,7 +117,7 @@ export async function getMatches(ort, text, matches) {
 ## Dependencies & Constraints
 
 - **Node.js 16+** required for build system
-- **ONNX Runtime Web 1.21+** for model execution
+- **ONNX Runtime Web 1.19.2** for model execution (newer versions have compatibility issues)
 - **extension-cli** handles Webpack bundling and manifest generation
 - Content Security Policy allows `'wasm-unsafe-eval'` for ONNX
 - Text length limits: 10k chars (standard), 60k (premium)

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,3 +7,8 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+    ignore:
+      # Keep webpack and onnxruntime packages at specific versions for compatibility
+      - dependency-name: "webpack"
+      - dependency-name: "onnxruntime-web"
+      - dependency-name: "onnxruntime-node"

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
             "version": "3.1.4",
             "dependencies": {
                 "@microsoft/applicationinsights-web": "^3.3.9",
-                "onnxruntime-web": "^1.21.1",
-                "webpack": "^5.99.9"
+                "onnxruntime-web": "1.19.2",
+                "webpack": "5.93.0"
             },
             "devDependencies": {
                 "@types/chai": "^5.2.2",
@@ -18,7 +18,7 @@
                 "@types/mocha": "^10.0.10",
                 "extension-cli": "^1.2.4",
                 "global": "^4.3.2",
-                "onnxruntime-node": "^1.21.1"
+                "onnxruntime-node": "1.19.2"
             }
         },
         "node_modules/@ampproject/remapping": {
@@ -2748,6 +2748,15 @@
                 "node": ">=0.4.0"
             }
         },
+        "node_modules/acorn-import-attributes": {
+            "version": "1.9.5",
+            "resolved": "https://registry.npmjs.org/acorn-import-attributes/-/acorn-import-attributes-1.9.5.tgz",
+            "integrity": "sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==",
+            "license": "MIT",
+            "peerDependencies": {
+                "acorn": "^8"
+            }
+        },
         "node_modules/acorn-jsx": {
             "version": "5.3.2",
             "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
@@ -2795,7 +2804,6 @@
             "version": "6.12.6",
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
             "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-            "dev": true,
             "dependencies": {
                 "fast-deep-equal": "^3.1.1",
                 "fast-json-stable-stringify": "^2.0.0",
@@ -2845,6 +2853,15 @@
             "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
             "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
             "license": "MIT"
+        },
+        "node_modules/ajv-keywords": {
+            "version": "3.5.2",
+            "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
+            "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
+            "license": "MIT",
+            "peerDependencies": {
+                "ajv": "^6.9.1"
+            }
         },
         "node_modules/ansi-colors": {
             "version": "4.1.3",
@@ -3467,14 +3484,6 @@
             "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
             "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
             "dev": true
-        },
-        "node_modules/boolean": {
-            "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/boolean/-/boolean-3.2.0.tgz",
-            "integrity": "sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==",
-            "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
-            "dev": true,
-            "license": "MIT"
         },
         "node_modules/brace-expansion": {
             "version": "1.1.11",
@@ -4348,13 +4357,6 @@
                 "node": ">=0.10.0"
             }
         },
-        "node_modules/detect-node": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
-            "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==",
-            "dev": true,
-            "license": "MIT"
-        },
         "node_modules/diff": {
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
@@ -5196,8 +5198,7 @@
         "node_modules/fast-json-stable-stringify": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-            "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
-            "dev": true
+            "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
         },
         "node_modules/fast-levenshtein": {
             "version": "2.0.6",
@@ -5354,10 +5355,10 @@
             }
         },
         "node_modules/flatbuffers": {
-            "version": "25.2.10",
-            "resolved": "https://registry.npmjs.org/flatbuffers/-/flatbuffers-25.2.10.tgz",
-            "integrity": "sha512-7JlN9ZvLDG1McO3kbX0k4v+SUAg48L1rIwEvN6ZQl/eCtgJz9UylTMzE9wrmYrcorgxm3CX/3T/w5VAub99UUw==",
-            "license": "Apache-2.0"
+            "version": "1.12.0",
+            "resolved": "https://registry.npmjs.org/flatbuffers/-/flatbuffers-1.12.0.tgz",
+            "integrity": "sha512-c7CZADjRcl6j0PlvFy0ZqXQ67qSEZfrVPynmnL+2zPc+NtMvrF8Y0QceMo7QqnSPc7+uWjUIAbvCQ5WIKlMVdQ==",
+            "license": "SEE LICENSE IN LICENSE.txt"
         },
         "node_modules/flatted": {
             "version": "3.2.7",
@@ -5703,37 +5704,6 @@
                 "process": "^0.11.10"
             }
         },
-        "node_modules/global-agent": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/global-agent/-/global-agent-3.0.0.tgz",
-            "integrity": "sha512-PT6XReJ+D07JvGoxQMkT6qji/jVNfX/h364XHZOWeRzy64sSFr+xJ5OX7LI3b4MPQzdL4H8Y8M0xzPpsVMwA8Q==",
-            "dev": true,
-            "license": "BSD-3-Clause",
-            "dependencies": {
-                "boolean": "^3.0.1",
-                "es6-error": "^4.1.1",
-                "matcher": "^3.0.0",
-                "roarr": "^2.15.3",
-                "semver": "^7.3.2",
-                "serialize-error": "^7.0.1"
-            },
-            "engines": {
-                "node": ">=10.0"
-            }
-        },
-        "node_modules/global-agent/node_modules/semver": {
-            "version": "7.7.1",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
-            "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
-            "dev": true,
-            "license": "ISC",
-            "bin": {
-                "semver": "bin/semver.js"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
         "node_modules/global-modules": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-1.0.0.tgz",
@@ -5783,23 +5753,6 @@
             "dev": true,
             "engines": {
                 "node": ">=4"
-            }
-        },
-        "node_modules/globalthis": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz",
-            "integrity": "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "define-properties": "^1.2.1",
-                "gopd": "^1.0.1"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/globby": {
@@ -7276,21 +7229,13 @@
         "node_modules/json-schema-traverse": {
             "version": "0.4.1",
             "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-            "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-            "dev": true
+            "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
         },
         "node_modules/json-stable-stringify-without-jsonify": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
             "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
             "dev": true
-        },
-        "node_modules/json-stringify-safe": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-            "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
-            "dev": true,
-            "license": "ISC"
         },
         "node_modules/json5": {
             "version": "2.2.3",
@@ -7956,19 +7901,6 @@
             },
             "engines": {
                 "node": ">=0.10.0"
-            }
-        },
-        "node_modules/matcher": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/matcher/-/matcher-3.0.0.tgz",
-            "integrity": "sha512-OkeDaAZ/bQCxeFAozM55PKcKU0yJMPGifLwV4Qgjitu+5MoAfSQN4lsLJeXZ1b8w0x+/Emda6MZgXS1jvsapng==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "escape-string-regexp": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=10"
             }
         },
         "node_modules/mdurl": {
@@ -9052,10 +8984,16 @@
                 "wrappy": "1"
             }
         },
+        "node_modules/onnxruntime-common": {
+            "version": "1.19.2",
+            "resolved": "https://registry.npmjs.org/onnxruntime-common/-/onnxruntime-common-1.19.2.tgz",
+            "integrity": "sha512-a4R7wYEVFbZBlp0BfhpbFWqe4opCor3KM+5Wm22Az3NGDcQMiU2hfG/0MfnBs+1ZrlSGmlgWeMcXQkDk1UFb8Q==",
+            "license": "MIT"
+        },
         "node_modules/onnxruntime-node": {
-            "version": "1.21.1",
-            "resolved": "https://registry.npmjs.org/onnxruntime-node/-/onnxruntime-node-1.21.1.tgz",
-            "integrity": "sha512-YThL/YYeGAeytecOvRcTKUORTIE2f8/iSo/JZgHFawWrV4zOY7fWLEaNuscgjmY5C5/VE/Wr7tm+ucSsc/AysQ==",
+            "version": "1.19.2",
+            "resolved": "https://registry.npmjs.org/onnxruntime-node/-/onnxruntime-node-1.19.2.tgz",
+            "integrity": "sha512-9eHMP/HKbbeUcqte1JYzaaRC8JPn7ojWeCeoyShO86TOR97OCyIyAIOGX3V95ErjslVhJRXY8Em/caIUc0hm1Q==",
             "dev": true,
             "hasInstallScript": true,
             "license": "MIT",
@@ -9065,37 +9003,23 @@
                 "linux"
             ],
             "dependencies": {
-                "global-agent": "^3.0.0",
-                "onnxruntime-common": "1.21.1",
+                "onnxruntime-common": "1.19.2",
                 "tar": "^7.0.1"
             }
         },
-        "node_modules/onnxruntime-node/node_modules/onnxruntime-common": {
-            "version": "1.21.1",
-            "resolved": "https://registry.npmjs.org/onnxruntime-common/-/onnxruntime-common-1.21.1.tgz",
-            "integrity": "sha512-E0q8+fMyJ+F8dvlwVsXcujrOc96lkPIDAZh3p6pjrZS4bzjowIcUMv48W5zOcFLtlWyycUlRPJWUUK2+3IL1eA==",
-            "dev": true,
-            "license": "MIT"
-        },
         "node_modules/onnxruntime-web": {
-            "version": "1.21.1",
-            "resolved": "https://registry.npmjs.org/onnxruntime-web/-/onnxruntime-web-1.21.1.tgz",
-            "integrity": "sha512-be7zmmN9z8vCj7g6LISNGyeWH9pZjomDjBZ1PYtodoE5VCX7ebabVl3zJHTGjOABFsj2D+kNfy48L7NXNGGU4w==",
+            "version": "1.19.2",
+            "resolved": "https://registry.npmjs.org/onnxruntime-web/-/onnxruntime-web-1.19.2.tgz",
+            "integrity": "sha512-r0ok6KpTUXR4WA+rHvUiZn7JoH02e8iS7XE1p5bXk7q3E0UaRFfYvpMNUHqEPiTBMuIssfBxDCQjUihV8dDFPg==",
             "license": "MIT",
             "dependencies": {
-                "flatbuffers": "^25.1.24",
+                "flatbuffers": "^1.12.0",
                 "guid-typescript": "^1.0.9",
                 "long": "^5.2.3",
-                "onnxruntime-common": "1.21.1",
+                "onnxruntime-common": "1.19.2",
                 "platform": "^1.3.6",
                 "protobufjs": "^7.2.4"
             }
-        },
-        "node_modules/onnxruntime-web/node_modules/onnxruntime-common": {
-            "version": "1.21.1",
-            "resolved": "https://registry.npmjs.org/onnxruntime-common/-/onnxruntime-common-1.21.1.tgz",
-            "integrity": "sha512-E0q8+fMyJ+F8dvlwVsXcujrOc96lkPIDAZh3p6pjrZS4bzjowIcUMv48W5zOcFLtlWyycUlRPJWUUK2+3IL1eA==",
-            "license": "MIT"
         },
         "node_modules/optionator": {
             "version": "0.9.1",
@@ -9743,7 +9667,6 @@
             "version": "2.3.0",
             "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",
             "integrity": "sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==",
-            "dev": true,
             "engines": {
                 "node": ">=6"
             }
@@ -10343,31 +10266,6 @@
                 "url": "https://github.com/sponsors/isaacs"
             }
         },
-        "node_modules/roarr": {
-            "version": "2.15.4",
-            "resolved": "https://registry.npmjs.org/roarr/-/roarr-2.15.4.tgz",
-            "integrity": "sha512-CHhPh+UNHD2GTXNYhPWLnU8ONHdI+5DI+4EYIAOaiD63rHeYlZvyh8P+in5999TTSFgUYuKUAjzRI4mdh/p+2A==",
-            "dev": true,
-            "license": "BSD-3-Clause",
-            "dependencies": {
-                "boolean": "^3.0.1",
-                "detect-node": "^2.0.4",
-                "globalthis": "^1.0.1",
-                "json-stringify-safe": "^5.0.1",
-                "semver-compare": "^1.0.0",
-                "sprintf-js": "^1.1.2"
-            },
-            "engines": {
-                "node": ">=8.0"
-            }
-        },
-        "node_modules/roarr/node_modules/sprintf-js": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
-            "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
-            "dev": true,
-            "license": "BSD-3-Clause"
-        },
         "node_modules/run-parallel": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -10599,13 +10497,6 @@
                 "semver": "bin/semver.js"
             }
         },
-        "node_modules/semver-compare": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
-            "integrity": "sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==",
-            "dev": true,
-            "license": "MIT"
-        },
         "node_modules/semver-greatest-satisfied-range": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/semver-greatest-satisfied-range/-/semver-greatest-satisfied-range-1.1.0.tgz",
@@ -10616,35 +10507,6 @@
             },
             "engines": {
                 "node": ">= 0.10"
-            }
-        },
-        "node_modules/serialize-error": {
-            "version": "7.0.1",
-            "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-7.0.1.tgz",
-            "integrity": "sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "type-fest": "^0.13.1"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/serialize-error/node_modules/type-fest": {
-            "version": "0.13.1",
-            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
-            "integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==",
-            "dev": true,
-            "license": "(MIT OR CC0-1.0)",
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/serialize-javascript": {
@@ -11915,7 +11777,6 @@
             "version": "4.4.1",
             "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
             "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
-            "dev": true,
             "dependencies": {
                 "punycode": "^2.1.0"
             }
@@ -12160,21 +12021,21 @@
             }
         },
         "node_modules/webpack": {
-            "version": "5.99.9",
-            "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.99.9.tgz",
-            "integrity": "sha512-brOPwM3JnmOa+7kd3NsmOUOwbDAj8FT9xDsG3IW0MgbN9yZV7Oi/s/+MNQ/EcSMqw7qfoRyXPoeEWT8zLVdVGg==",
+            "version": "5.93.0",
+            "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.93.0.tgz",
+            "integrity": "sha512-Y0m5oEY1LRuwly578VqluorkXbvXKh7U3rLoQCEO04M97ScRr44afGVkI0FQFsXzysk5OgFAxjZAb9rsGQVihA==",
             "license": "MIT",
             "dependencies": {
-                "@types/eslint-scope": "^3.7.7",
-                "@types/estree": "^1.0.6",
-                "@types/json-schema": "^7.0.15",
-                "@webassemblyjs/ast": "^1.14.1",
-                "@webassemblyjs/wasm-edit": "^1.14.1",
-                "@webassemblyjs/wasm-parser": "^1.14.1",
-                "acorn": "^8.14.0",
-                "browserslist": "^4.24.0",
+                "@types/eslint-scope": "^3.7.3",
+                "@types/estree": "^1.0.5",
+                "@webassemblyjs/ast": "^1.12.1",
+                "@webassemblyjs/wasm-edit": "^1.12.1",
+                "@webassemblyjs/wasm-parser": "^1.12.1",
+                "acorn": "^8.7.1",
+                "acorn-import-attributes": "^1.9.5",
+                "browserslist": "^4.21.10",
                 "chrome-trace-event": "^1.0.2",
-                "enhanced-resolve": "^5.17.1",
+                "enhanced-resolve": "^5.17.0",
                 "es-module-lexer": "^1.2.1",
                 "eslint-scope": "5.1.1",
                 "events": "^3.2.0",
@@ -12184,9 +12045,9 @@
                 "loader-runner": "^4.2.0",
                 "mime-types": "^2.1.27",
                 "neo-async": "^2.6.2",
-                "schema-utils": "^4.3.2",
+                "schema-utils": "^3.2.0",
                 "tapable": "^2.1.1",
-                "terser-webpack-plugin": "^5.3.11",
+                "terser-webpack-plugin": "^5.3.10",
                 "watchpack": "^2.4.1",
                 "webpack-sources": "^3.2.3"
             },
@@ -12269,6 +12130,24 @@
             "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
             "engines": {
                 "node": ">=4.0"
+            }
+        },
+        "node_modules/webpack/node_modules/schema-utils": {
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.3.0.tgz",
+            "integrity": "sha512-pN/yOAvcC+5rQ5nERGuwrjLlYvLTbCibnZ1I7B1LaiAz9BRBlE9GMgE/eqV30P7aJQUf7Ddimy/RsbYO/GrVGg==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/json-schema": "^7.0.8",
+                "ajv": "^6.12.5",
+                "ajv-keywords": "^3.5.2"
+            },
+            "engines": {
+                "node": ">= 10.13.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/webpack"
             }
         },
         "node_modules/whatwg-encoding": {
@@ -14620,6 +14499,12 @@
                 }
             }
         },
+        "acorn-import-attributes": {
+            "version": "1.9.5",
+            "resolved": "https://registry.npmjs.org/acorn-import-attributes/-/acorn-import-attributes-1.9.5.tgz",
+            "integrity": "sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==",
+            "requires": {}
+        },
         "acorn-jsx": {
             "version": "5.3.2",
             "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
@@ -14656,7 +14541,6 @@
             "version": "6.12.6",
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
             "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-            "dev": true,
             "requires": {
                 "fast-deep-equal": "^3.1.1",
                 "fast-json-stable-stringify": "^2.0.0",
@@ -14689,6 +14573,12 @@
                     "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
                 }
             }
+        },
+        "ajv-keywords": {
+            "version": "3.5.2",
+            "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
+            "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
+            "requires": {}
         },
         "ansi-colors": {
             "version": "4.1.3",
@@ -15173,12 +15063,6 @@
             "version": "3.7.2",
             "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
             "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
-            "dev": true
-        },
-        "boolean": {
-            "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/boolean/-/boolean-3.2.0.tgz",
-            "integrity": "sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==",
             "dev": true
         },
         "brace-expansion": {
@@ -15845,12 +15729,6 @@
             "integrity": "sha512-DtCOLG98P007x7wiiOmfI0fi3eIKyWiLTGJ2MDnVi/E04lWGbf+JzrRHMm0rgIIZJGtHpKpbVgLWHrv8xXpc3Q==",
             "dev": true
         },
-        "detect-node": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
-            "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==",
-            "dev": true
-        },
         "diff": {
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
@@ -16514,8 +16392,7 @@
         "fast-json-stable-stringify": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-            "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
-            "dev": true
+            "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
         },
         "fast-levenshtein": {
             "version": "2.0.6",
@@ -16631,9 +16508,9 @@
             }
         },
         "flatbuffers": {
-            "version": "25.2.10",
-            "resolved": "https://registry.npmjs.org/flatbuffers/-/flatbuffers-25.2.10.tgz",
-            "integrity": "sha512-7JlN9ZvLDG1McO3kbX0k4v+SUAg48L1rIwEvN6ZQl/eCtgJz9UylTMzE9wrmYrcorgxm3CX/3T/w5VAub99UUw=="
+            "version": "1.12.0",
+            "resolved": "https://registry.npmjs.org/flatbuffers/-/flatbuffers-1.12.0.tgz",
+            "integrity": "sha512-c7CZADjRcl6j0PlvFy0ZqXQ67qSEZfrVPynmnL+2zPc+NtMvrF8Y0QceMo7QqnSPc7+uWjUIAbvCQ5WIKlMVdQ=="
         },
         "flatted": {
             "version": "3.2.7",
@@ -16901,28 +16778,6 @@
                 "process": "^0.11.10"
             }
         },
-        "global-agent": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/global-agent/-/global-agent-3.0.0.tgz",
-            "integrity": "sha512-PT6XReJ+D07JvGoxQMkT6qji/jVNfX/h364XHZOWeRzy64sSFr+xJ5OX7LI3b4MPQzdL4H8Y8M0xzPpsVMwA8Q==",
-            "dev": true,
-            "requires": {
-                "boolean": "^3.0.1",
-                "es6-error": "^4.1.1",
-                "matcher": "^3.0.0",
-                "roarr": "^2.15.3",
-                "semver": "^7.3.2",
-                "serialize-error": "^7.0.1"
-            },
-            "dependencies": {
-                "semver": {
-                    "version": "7.7.1",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
-                    "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
-                    "dev": true
-                }
-            }
-        },
         "global-modules": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-1.0.0.tgz",
@@ -16963,16 +16818,6 @@
             "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
             "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
             "dev": true
-        },
-        "globalthis": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz",
-            "integrity": "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==",
-            "dev": true,
-            "requires": {
-                "define-properties": "^1.2.1",
-                "gopd": "^1.0.1"
-            }
         },
         "globby": {
             "version": "11.1.0",
@@ -18134,19 +17979,12 @@
         "json-schema-traverse": {
             "version": "0.4.1",
             "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-            "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-            "dev": true
+            "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
         },
         "json-stable-stringify-without-jsonify": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
             "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
-            "dev": true
-        },
-        "json-stringify-safe": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-            "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
             "dev": true
         },
         "json5": {
@@ -18682,15 +18520,6 @@
                         "to-regex": "^3.0.2"
                     }
                 }
-            }
-        },
-        "matcher": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/matcher/-/matcher-3.0.0.tgz",
-            "integrity": "sha512-OkeDaAZ/bQCxeFAozM55PKcKU0yJMPGifLwV4Qgjitu+5MoAfSQN4lsLJeXZ1b8w0x+/Emda6MZgXS1jvsapng==",
-            "dev": true,
-            "requires": {
-                "escape-string-regexp": "^4.0.0"
             }
         },
         "mdurl": {
@@ -19529,43 +19358,32 @@
                 "wrappy": "1"
             }
         },
+        "onnxruntime-common": {
+            "version": "1.19.2",
+            "resolved": "https://registry.npmjs.org/onnxruntime-common/-/onnxruntime-common-1.19.2.tgz",
+            "integrity": "sha512-a4R7wYEVFbZBlp0BfhpbFWqe4opCor3KM+5Wm22Az3NGDcQMiU2hfG/0MfnBs+1ZrlSGmlgWeMcXQkDk1UFb8Q=="
+        },
         "onnxruntime-node": {
-            "version": "1.21.1",
-            "resolved": "https://registry.npmjs.org/onnxruntime-node/-/onnxruntime-node-1.21.1.tgz",
-            "integrity": "sha512-YThL/YYeGAeytecOvRcTKUORTIE2f8/iSo/JZgHFawWrV4zOY7fWLEaNuscgjmY5C5/VE/Wr7tm+ucSsc/AysQ==",
+            "version": "1.19.2",
+            "resolved": "https://registry.npmjs.org/onnxruntime-node/-/onnxruntime-node-1.19.2.tgz",
+            "integrity": "sha512-9eHMP/HKbbeUcqte1JYzaaRC8JPn7ojWeCeoyShO86TOR97OCyIyAIOGX3V95ErjslVhJRXY8Em/caIUc0hm1Q==",
             "dev": true,
             "requires": {
-                "global-agent": "^3.0.0",
-                "onnxruntime-common": "1.21.1",
+                "onnxruntime-common": "1.19.2",
                 "tar": "^7.0.1"
-            },
-            "dependencies": {
-                "onnxruntime-common": {
-                    "version": "1.21.1",
-                    "resolved": "https://registry.npmjs.org/onnxruntime-common/-/onnxruntime-common-1.21.1.tgz",
-                    "integrity": "sha512-E0q8+fMyJ+F8dvlwVsXcujrOc96lkPIDAZh3p6pjrZS4bzjowIcUMv48W5zOcFLtlWyycUlRPJWUUK2+3IL1eA==",
-                    "dev": true
-                }
             }
         },
         "onnxruntime-web": {
-            "version": "1.21.1",
-            "resolved": "https://registry.npmjs.org/onnxruntime-web/-/onnxruntime-web-1.21.1.tgz",
-            "integrity": "sha512-be7zmmN9z8vCj7g6LISNGyeWH9pZjomDjBZ1PYtodoE5VCX7ebabVl3zJHTGjOABFsj2D+kNfy48L7NXNGGU4w==",
+            "version": "1.19.2",
+            "resolved": "https://registry.npmjs.org/onnxruntime-web/-/onnxruntime-web-1.19.2.tgz",
+            "integrity": "sha512-r0ok6KpTUXR4WA+rHvUiZn7JoH02e8iS7XE1p5bXk7q3E0UaRFfYvpMNUHqEPiTBMuIssfBxDCQjUihV8dDFPg==",
             "requires": {
-                "flatbuffers": "^25.1.24",
+                "flatbuffers": "^1.12.0",
                 "guid-typescript": "^1.0.9",
                 "long": "^5.2.3",
-                "onnxruntime-common": "1.21.1",
+                "onnxruntime-common": "1.19.2",
                 "platform": "^1.3.6",
                 "protobufjs": "^7.2.4"
-            },
-            "dependencies": {
-                "onnxruntime-common": {
-                    "version": "1.21.1",
-                    "resolved": "https://registry.npmjs.org/onnxruntime-common/-/onnxruntime-common-1.21.1.tgz",
-                    "integrity": "sha512-E0q8+fMyJ+F8dvlwVsXcujrOc96lkPIDAZh3p6pjrZS4bzjowIcUMv48W5zOcFLtlWyycUlRPJWUUK2+3IL1eA=="
-                }
             }
         },
         "optionator": {
@@ -20069,8 +19887,7 @@
         "punycode": {
             "version": "2.3.0",
             "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",
-            "integrity": "sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==",
-            "dev": true
+            "integrity": "sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA=="
         },
         "querystringify": {
             "version": "2.2.0",
@@ -20539,28 +20356,6 @@
                 "glob": "^7.1.3"
             }
         },
-        "roarr": {
-            "version": "2.15.4",
-            "resolved": "https://registry.npmjs.org/roarr/-/roarr-2.15.4.tgz",
-            "integrity": "sha512-CHhPh+UNHD2GTXNYhPWLnU8ONHdI+5DI+4EYIAOaiD63rHeYlZvyh8P+in5999TTSFgUYuKUAjzRI4mdh/p+2A==",
-            "dev": true,
-            "requires": {
-                "boolean": "^3.0.1",
-                "detect-node": "^2.0.4",
-                "globalthis": "^1.0.1",
-                "json-stringify-safe": "^5.0.1",
-                "semver-compare": "^1.0.0",
-                "sprintf-js": "^1.1.2"
-            },
-            "dependencies": {
-                "sprintf-js": {
-                    "version": "1.1.3",
-                    "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
-                    "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
-                    "dev": true
-                }
-            }
-        },
         "run-parallel": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -20719,12 +20514,6 @@
             "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
             "dev": true
         },
-        "semver-compare": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
-            "integrity": "sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==",
-            "dev": true
-        },
         "semver-greatest-satisfied-range": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/semver-greatest-satisfied-range/-/semver-greatest-satisfied-range-1.1.0.tgz",
@@ -20732,23 +20521,6 @@
             "dev": true,
             "requires": {
                 "sver-compat": "^1.5.0"
-            }
-        },
-        "serialize-error": {
-            "version": "7.0.1",
-            "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-7.0.1.tgz",
-            "integrity": "sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw==",
-            "dev": true,
-            "requires": {
-                "type-fest": "^0.13.1"
-            },
-            "dependencies": {
-                "type-fest": {
-                    "version": "0.13.1",
-                    "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
-                    "integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==",
-                    "dev": true
-                }
             }
         },
         "serialize-javascript": {
@@ -21771,7 +21543,6 @@
             "version": "4.4.1",
             "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
             "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
-            "dev": true,
             "requires": {
                 "punycode": "^2.1.0"
             }
@@ -21983,20 +21754,20 @@
             "dev": true
         },
         "webpack": {
-            "version": "5.99.9",
-            "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.99.9.tgz",
-            "integrity": "sha512-brOPwM3JnmOa+7kd3NsmOUOwbDAj8FT9xDsG3IW0MgbN9yZV7Oi/s/+MNQ/EcSMqw7qfoRyXPoeEWT8zLVdVGg==",
+            "version": "5.93.0",
+            "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.93.0.tgz",
+            "integrity": "sha512-Y0m5oEY1LRuwly578VqluorkXbvXKh7U3rLoQCEO04M97ScRr44afGVkI0FQFsXzysk5OgFAxjZAb9rsGQVihA==",
             "requires": {
-                "@types/eslint-scope": "^3.7.7",
-                "@types/estree": "^1.0.6",
-                "@types/json-schema": "^7.0.15",
-                "@webassemblyjs/ast": "^1.14.1",
-                "@webassemblyjs/wasm-edit": "^1.14.1",
-                "@webassemblyjs/wasm-parser": "^1.14.1",
-                "acorn": "^8.14.0",
-                "browserslist": "^4.24.0",
+                "@types/eslint-scope": "^3.7.3",
+                "@types/estree": "^1.0.5",
+                "@webassemblyjs/ast": "^1.12.1",
+                "@webassemblyjs/wasm-edit": "^1.12.1",
+                "@webassemblyjs/wasm-parser": "^1.12.1",
+                "acorn": "^8.7.1",
+                "acorn-import-attributes": "^1.9.5",
+                "browserslist": "^4.21.10",
                 "chrome-trace-event": "^1.0.2",
-                "enhanced-resolve": "^5.17.1",
+                "enhanced-resolve": "^5.17.0",
                 "es-module-lexer": "^1.2.1",
                 "eslint-scope": "5.1.1",
                 "events": "^3.2.0",
@@ -22006,9 +21777,9 @@
                 "loader-runner": "^4.2.0",
                 "mime-types": "^2.1.27",
                 "neo-async": "^2.6.2",
-                "schema-utils": "^4.3.2",
+                "schema-utils": "^3.2.0",
                 "tapable": "^2.1.1",
-                "terser-webpack-plugin": "^5.3.11",
+                "terser-webpack-plugin": "^5.3.10",
                 "watchpack": "^2.4.1",
                 "webpack-sources": "^3.2.3"
             },
@@ -22026,6 +21797,16 @@
                     "version": "4.3.0",
                     "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
                     "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw=="
+                },
+                "schema-utils": {
+                    "version": "3.3.0",
+                    "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.3.0.tgz",
+                    "integrity": "sha512-pN/yOAvcC+5rQ5nERGuwrjLlYvLTbCibnZ1I7B1LaiAz9BRBlE9GMgE/eqV30P7aJQUf7Ddimy/RsbYO/GrVGg==",
+                    "requires": {
+                        "@types/json-schema": "^7.0.8",
+                        "ajv": "^6.12.5",
+                        "ajv-keywords": "^3.5.2"
+                    }
                 }
             }
         },

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
         "@types/mocha": "^10.0.10",
         "extension-cli": "^1.2.4",
         "global": "^4.3.2",
-        "onnxruntime-node": "^1.21.1"
+        "onnxruntime-node": "1.19.2"
     },
     "xtdocs": {
         "source": {
@@ -62,8 +62,8 @@
     },
     "dependencies": {
         "@microsoft/applicationinsights-web": "^3.3.9",
-        "onnxruntime-web": "^1.21.1",
-        "webpack": "^5.99.9"
+        "onnxruntime-web": "1.19.2",
+        "webpack": "5.93.0"
     },
     "overrides": {
         "braces": "3.0.3",


### PR DESCRIPTION
The browser extension is running into errors like:

    validator.js:112  Error calling getMatches: Error: no available backend found. ERR: [wasm] TypeError: import() is disallowed on ServiceWorkerGlobalScope by the HTML specification. See https://github.com/w3c/ServiceWorker/issues/1356., [cpu] Error: previous call to 'initWasm()' failed.